### PR TITLE
Add GPT-OSS 20B CUDA support

### DIFF
--- a/crates/rvllm-model-loader/src/gpu_loader.rs
+++ b/crates/rvllm-model-loader/src/gpu_loader.rs
@@ -1,9 +1,12 @@
-//! SafeTensors GPU loader -- loads weights directly to CUDA device memory as f16.
+//! SafeTensors GPU loader -- loads weights directly to CUDA device memory.
 //!
 //! Memory-maps the safetensors file(s), parses the header to find tensor
-//! metadata, then uploads each tensor's raw bytes to GPU as f16.
+//! metadata, then uploads each tensor's raw bytes to GPU.
 //!
-//! All dtypes on disk (F16, BF16, F32) are converted to f16 at load time.
+//! Supports two dtype modes:
+//! - `GpuDType::F32`: all weights widened to f32 (original path)
+//! - `GpuDType::F16`: f16 kept as-is, bf16 narrowed to f16, f32 narrowed to f16
+//!   Halves VRAM and enables hgemm.
 
 #[cfg(feature = "cuda")]
 mod inner {
@@ -14,16 +17,34 @@ mod inner {
     use cudarc::driver::{CudaSlice, CudaStream};
     use memmap2::Mmap;
     use rvllm_core::error::{LLMError, Result};
-    use tracing::{debug, info};
+    use tracing::{debug, info, warn};
 
-    /// Load all safetensors weights as f16 on GPU.
-    ///
-    /// F16 weights are uploaded directly (zero conversion), BF16 are converted
-    /// to f16 on the host, and F32 weights are narrowed to f16.
+    /// Target dtype for GPU weight storage.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum GpuDType {
+        /// Widen everything to f32 (legacy path).
+        F32,
+        /// Keep f16 as-is, convert bf16->f16, narrow f32->f16. Halves VRAM.
+        F16,
+    }
+
+    // -----------------------------------------------------------------------
+    // Public API
+    // -----------------------------------------------------------------------
+
+    /// Load all safetensors weights as f32 (legacy API, unchanged signature).
     pub fn load_weights_to_gpu(
         path: &Path,
         stream: &Arc<CudaStream>,
-    ) -> Result<HashMap<String, CudaSlice<half::f16>>> {
+    ) -> Result<HashMap<String, CudaSlice<f32>>> {
+        load_weights_to_gpu_with_shapes(path, stream).map(|(weights, _shapes)| weights)
+    }
+
+    /// Load all safetensors weights as f32 and preserve tensor shapes.
+    pub fn load_weights_to_gpu_with_shapes(
+        path: &Path,
+        stream: &Arc<CudaStream>,
+    ) -> Result<(HashMap<String, CudaSlice<f32>>, HashMap<String, Vec<usize>>)> {
         if path.is_dir() {
             load_sharded_to_gpu(path, stream)
         } else {
@@ -31,10 +52,51 @@ mod inner {
         }
     }
 
-    fn load_single_to_gpu(
+    /// Load all safetensors weights as f16 on GPU.
+    ///
+    /// F16 weights are uploaded directly (zero widen), BF16 are converted to
+    /// f16 on the host, and f32 weights are narrowed to f16. This halves VRAM
+    /// usage and enables the hgemm (half-precision GEMM) path.
+    pub fn load_weights_to_gpu_f16(
         path: &Path,
         stream: &Arc<CudaStream>,
     ) -> Result<HashMap<String, CudaSlice<half::f16>>> {
+        load_weights_to_gpu_f16_with_shapes(path, stream).map(|(weights, _shapes)| weights)
+    }
+
+    /// Load all safetensors weights as f16 on GPU and preserve tensor shapes.
+    pub fn load_weights_to_gpu_f16_with_shapes(
+        path: &Path,
+        stream: &Arc<CudaStream>,
+    ) -> Result<(HashMap<String, CudaSlice<half::f16>>, HashMap<String, Vec<usize>>)> {
+        if path.is_dir() {
+            load_sharded_to_gpu_f16(path, stream)
+        } else {
+            load_single_to_gpu_f16(path, stream)
+        }
+    }
+
+    /// Load all raw `U8` tensors from safetensors files into host memory.
+    ///
+    /// GPT-OSS stores MXFP4 expert blocks/scales as `U8`, so these tensors
+    /// must survive loader setup even though they are not uploaded through the
+    /// normal f32/f16 weight maps.
+    pub fn load_u8_weights_to_host(path: &Path) -> Result<HashMap<String, Vec<u8>>> {
+        if path.is_dir() {
+            load_sharded_u8_to_host(path)
+        } else {
+            load_single_u8_to_host(path)
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // F32 path (unchanged)
+    // -----------------------------------------------------------------------
+
+    fn load_single_to_gpu(
+        path: &Path,
+        stream: &Arc<CudaStream>,
+    ) -> Result<(HashMap<String, CudaSlice<f32>>, HashMap<String, Vec<usize>>)> {
         info!("gpu_loader: memory-mapping {}", path.display());
 
         let file = std::fs::File::open(path)?;
@@ -45,7 +107,8 @@ mod inner {
 
         let (header, data_start) = parse_safetensors_header(data, path)?;
 
-        let mut weights: HashMap<String, CudaSlice<half::f16>> = HashMap::new();
+        let mut weights: HashMap<String, CudaSlice<f32>> = HashMap::new();
+        let mut shapes: HashMap<String, Vec<usize>> = HashMap::new();
 
         for (name, meta) in &header {
             if name == "__metadata__" {
@@ -55,6 +118,107 @@ mod inner {
             let (dtype_str, shape, tensor_bytes) =
                 parse_tensor_meta(meta, name, data, data_start)?;
             let numel: usize = shape.iter().product();
+
+            if dtype_str == "U8" {
+                debug!(tensor = name.as_str(), shape = ?shape, "skipping U8 tensor on f32 GPU path");
+                shapes.insert(name.clone(), shape);
+                continue;
+            }
+
+            let f32_host = convert_to_f32(tensor_bytes, dtype_str, numel, name)?;
+
+            let gpu_slice = stream.clone_htod(&f32_host).map_err(|e| {
+                LLMError::GpuError(format!(
+                    "clone_htod failed for tensor {} ({} floats): {}",
+                    name,
+                    f32_host.len(),
+                    e
+                ))
+            })?;
+
+            debug!(
+                tensor = name.as_str(),
+                dtype = dtype_str,
+                shape = ?shape,
+                numel = numel,
+                "uploaded tensor to GPU (f32)"
+            );
+
+            weights.insert(name.clone(), gpu_slice);
+            shapes.insert(name.clone(), shape);
+        }
+
+        info!(
+            "gpu_loader: loaded {} tensors from {} to GPU (f32)",
+            weights.len(),
+            path.display()
+        );
+        Ok((weights, shapes))
+    }
+
+    fn load_sharded_to_gpu(
+        dir: &Path,
+        stream: &Arc<CudaStream>,
+    ) -> Result<(HashMap<String, CudaSlice<f32>>, HashMap<String, Vec<usize>>)> {
+        let shard_files = collect_shards(dir)?;
+
+        info!(
+            "gpu_loader: loading {} shards from {} to GPU (f32)",
+            shard_files.len(),
+            dir.display()
+        );
+
+        let mut all_weights: HashMap<String, CudaSlice<f32>> = HashMap::new();
+        let mut all_shapes: HashMap<String, Vec<usize>> = HashMap::new();
+        for shard_path in &shard_files {
+            let (shard_weights, shard_shapes) = load_single_to_gpu(shard_path, stream)?;
+            all_weights.extend(shard_weights);
+            all_shapes.extend(shard_shapes);
+        }
+
+        info!(
+            "gpu_loader: loaded {} total tensors from {} shards (f32)",
+            all_weights.len(),
+            shard_files.len()
+        );
+        Ok((all_weights, all_shapes))
+    }
+
+    // -----------------------------------------------------------------------
+    // F16 path (new)
+    // -----------------------------------------------------------------------
+
+    fn load_single_to_gpu_f16(
+        path: &Path,
+        stream: &Arc<CudaStream>,
+    ) -> Result<(HashMap<String, CudaSlice<half::f16>>, HashMap<String, Vec<usize>>)> {
+        info!("gpu_loader: memory-mapping {} (f16 mode)", path.display());
+
+        let file = std::fs::File::open(path)?;
+        let mmap = unsafe { Mmap::map(&file) }.map_err(|e| {
+            LLMError::ModelError(format!("mmap failed for {}: {}", path.display(), e))
+        })?;
+        let data: &[u8] = &mmap;
+
+        let (header, data_start) = parse_safetensors_header(data, path)?;
+
+        let mut weights: HashMap<String, CudaSlice<half::f16>> = HashMap::new();
+        let mut shapes: HashMap<String, Vec<usize>> = HashMap::new();
+
+        for (name, meta) in &header {
+            if name == "__metadata__" {
+                continue;
+            }
+
+            let (dtype_str, shape, tensor_bytes) =
+                parse_tensor_meta(meta, name, data, data_start)?;
+            let numel: usize = shape.iter().product();
+
+            if dtype_str == "U8" {
+                debug!(tensor = name.as_str(), shape = ?shape, "skipping U8 tensor on f16 GPU path");
+                shapes.insert(name.clone(), shape);
+                continue;
+            }
 
             let f16_host = convert_to_f16(tensor_bytes, dtype_str, numel, name)?;
 
@@ -76,6 +240,7 @@ mod inner {
             );
 
             weights.insert(name.clone(), gpu_slice);
+            shapes.insert(name.clone(), shape);
         }
 
         info!(
@@ -83,13 +248,13 @@ mod inner {
             weights.len(),
             path.display()
         );
-        Ok(weights)
+        Ok((weights, shapes))
     }
 
-    fn load_sharded_to_gpu(
+    fn load_sharded_to_gpu_f16(
         dir: &Path,
         stream: &Arc<CudaStream>,
-    ) -> Result<HashMap<String, CudaSlice<half::f16>>> {
+    ) -> Result<(HashMap<String, CudaSlice<half::f16>>, HashMap<String, Vec<usize>>)> {
         let shard_files = collect_shards(dir)?;
 
         info!(
@@ -99,9 +264,11 @@ mod inner {
         );
 
         let mut all_weights: HashMap<String, CudaSlice<half::f16>> = HashMap::new();
+        let mut all_shapes: HashMap<String, Vec<usize>> = HashMap::new();
         for shard_path in &shard_files {
-            let shard = load_single_to_gpu(shard_path, stream)?;
-            all_weights.extend(shard);
+            let (shard_weights, shard_shapes) = load_single_to_gpu_f16(shard_path, stream)?;
+            all_weights.extend(shard_weights);
+            all_shapes.extend(shard_shapes);
         }
 
         info!(
@@ -109,13 +276,14 @@ mod inner {
             all_weights.len(),
             shard_files.len()
         );
-        Ok(all_weights)
+        Ok((all_weights, all_shapes))
     }
 
     // -----------------------------------------------------------------------
     // Shared helpers
     // -----------------------------------------------------------------------
 
+    /// Parse the safetensors header from raw mmap bytes.
     fn parse_safetensors_header(
         data: &[u8],
         path: &Path,
@@ -147,6 +315,7 @@ mod inner {
         Ok((header, 8 + header_size))
     }
 
+    /// Extract dtype, shape, and byte slice for a single tensor from header metadata.
     fn parse_tensor_meta<'a, 'b>(
         meta: &'b serde_json::Value,
         name: &str,
@@ -207,6 +376,7 @@ mod inner {
         Ok((dtype_str, shape, &data[abs_start..abs_end]))
     }
 
+    /// Collect sorted shard file paths from a directory.
     fn collect_shards(dir: &Path) -> Result<Vec<std::path::PathBuf>> {
         let mut shard_files: Vec<_> = std::fs::read_dir(dir)?
             .filter_map(|e| e.ok())
@@ -229,10 +399,117 @@ mod inner {
         Ok(shard_files)
     }
 
-    /// Convert raw tensor bytes to `Vec<half::f16>`.
+    fn load_single_u8_to_host(path: &Path) -> Result<HashMap<String, Vec<u8>>> {
+        info!("gpu_loader: memory-mapping {} (host U8 path)", path.display());
+
+        let file = std::fs::File::open(path)?;
+        let mmap = unsafe { Mmap::map(&file) }.map_err(|e| {
+            LLMError::ModelError(format!("mmap failed for {}: {}", path.display(), e))
+        })?;
+        let data: &[u8] = &mmap;
+
+        let (header, data_start) = parse_safetensors_header(data, path)?;
+        let mut weights = HashMap::new();
+
+        for (name, meta) in &header {
+            if name == "__metadata__" {
+                continue;
+            }
+
+            let (dtype_str, _shape, tensor_bytes) =
+                parse_tensor_meta(meta, name, data, data_start)?;
+            if dtype_str == "U8" {
+                weights.insert(name.clone(), tensor_bytes.to_vec());
+            }
+        }
+
+        Ok(weights)
+    }
+
+    fn load_sharded_u8_to_host(dir: &Path) -> Result<HashMap<String, Vec<u8>>> {
+        let shard_files = collect_shards(dir)?;
+        let mut all_weights = HashMap::new();
+        for shard_path in &shard_files {
+            all_weights.extend(load_single_u8_to_host(shard_path)?);
+        }
+        Ok(all_weights)
+    }
+
+    // -----------------------------------------------------------------------
+    // Dtype conversion
+    // -----------------------------------------------------------------------
+
+    /// Convert raw tensor bytes to `Vec<f32>` based on the safetensors dtype string.
     ///
-    /// - F16: reinterpret bytes directly (zero conversion).
-    /// - BF16: convert bf16 -> f16 via f32 intermediate.
+    /// Supported dtypes: F32 (zero-copy reinterpret), F16, BF16 (widened to f32).
+    fn convert_to_f32(
+        bytes: &[u8],
+        dtype_str: &str,
+        numel: usize,
+        tensor_name: &str,
+    ) -> Result<Vec<f32>> {
+        match dtype_str {
+            "F32" => {
+                if bytes.len() != numel * 4 {
+                    return Err(LLMError::ModelError(format!(
+                        "tensor {} F32 size mismatch: {} bytes for {} elements",
+                        tensor_name,
+                        bytes.len(),
+                        numel
+                    )));
+                }
+                let mut out = vec![0f32; numel];
+                // SAFETY: f32 is Pod, byte count verified.
+                let src =
+                    unsafe { std::slice::from_raw_parts(bytes.as_ptr() as *const f32, numel) };
+                out.copy_from_slice(src);
+                Ok(out)
+            }
+            "F16" => {
+                if bytes.len() != numel * 2 {
+                    return Err(LLMError::ModelError(format!(
+                        "tensor {} F16 size mismatch: {} bytes for {} elements",
+                        tensor_name,
+                        bytes.len(),
+                        numel
+                    )));
+                }
+                let mut out = Vec::with_capacity(numel);
+                for i in 0..numel {
+                    let bits = u16::from_le_bytes([bytes[i * 2], bytes[i * 2 + 1]]);
+                    let val = half::f16::from_bits(bits);
+                    out.push(val.to_f32());
+                }
+                Ok(out)
+            }
+            "BF16" => {
+                if bytes.len() != numel * 2 {
+                    return Err(LLMError::ModelError(format!(
+                        "tensor {} BF16 size mismatch: {} bytes for {} elements",
+                        tensor_name,
+                        bytes.len(),
+                        numel
+                    )));
+                }
+                let mut out = Vec::with_capacity(numel);
+                for i in 0..numel {
+                    let bits = u16::from_le_bytes([bytes[i * 2], bytes[i * 2 + 1]]);
+                    let val = half::bf16::from_bits(bits);
+                    out.push(val.to_f32());
+                }
+                Ok(out)
+            }
+            _ => Err(LLMError::ModelError(format!(
+                "gpu_loader: unsupported dtype '{}' for tensor '{}', only F32/F16/BF16 supported",
+                dtype_str, tensor_name
+            ))),
+        }
+    }
+
+    /// Convert raw tensor bytes to `Vec<half::f16>` for the f16 GPU path.
+    ///
+    /// - F16: reinterpret bytes directly as half::f16 (no conversion).
+    /// - BF16: convert bf16 -> f16 on the host (no intermediate f32 widen).
     /// - F32: narrow f32 -> f16.
     fn convert_to_f16(
         bytes: &[u8],
@@ -250,7 +527,10 @@ mod inner {
                         numel
                     )));
                 }
+                // Direct reinterpret -- no conversion needed.
                 let mut out = vec![half::f16::ZERO; numel];
+                // SAFETY: half::f16 is repr(transparent) over u16, 2 bytes each,
+                // byte count verified above. Source is valid mmap data.
                 unsafe {
                     std::ptr::copy_nonoverlapping(
                         bytes.as_ptr(),
@@ -261,6 +541,12 @@ mod inner {
                 Ok(out)
             }
             "BF16" => {
+                // Convert bf16 -> f16 directly without widening to f32.
+                // bf16 has 8-bit exponent + 7-bit mantissa
+                // f16  has 5-bit exponent + 10-bit mantissa
+                // We go bf16 -> f32 -> f16 per element. The bf16->f32 step is
+                // a cheap bit shift (no real work), and f32->f16 is the
+                // standard narrowing. This avoids allocating a full f32 buffer.
                 if bytes.len() != numel * 2 {
                     return Err(LLMError::ModelError(format!(
                         "tensor {} BF16 size mismatch: {} bytes for {} elements",
@@ -273,6 +559,7 @@ mod inner {
                 for i in 0..numel {
                     let bits = u16::from_le_bytes([bytes[i * 2], bytes[i * 2 + 1]]);
                     let bf = half::bf16::from_bits(bits);
+                    // bf16->f32 is a trivial bit shift, then f32->f16 narrow
                     out.push(half::f16::from_f32(bf.to_f32()));
                 }
                 Ok(out)
@@ -286,7 +573,9 @@ mod inner {
                         numel
                     )));
                 }
+                // Narrow f32 -> f16
                 let mut out = Vec::with_capacity(numel);
+                // SAFETY: f32 is Pod, byte count verified.
                 let src =
                     unsafe { std::slice::from_raw_parts(bytes.as_ptr() as *const f32, numel) };
                 for &v in src {
@@ -303,7 +592,10 @@ mod inner {
 }
 
 #[cfg(feature = "cuda")]
-pub use inner::load_weights_to_gpu;
+pub use inner::{
+    load_u8_weights_to_host, load_weights_to_gpu, load_weights_to_gpu_f16,
+    load_weights_to_gpu_f16_with_shapes, load_weights_to_gpu_with_shapes, GpuDType,
+};
 
 #[cfg(test)]
 mod tests {

--- a/crates/rvllm-model-loader/src/gpu_weights.rs
+++ b/crates/rvllm-model-loader/src/gpu_weights.rs
@@ -1,6 +1,6 @@
-//! GPU model weights container backed by CUDA device memory (f16 only).
+//! GPU model weights container backed by CUDA device memory.
 //!
-//! Holds all model weight tensors as `CudaSlice<f16>` on a single device,
+//! Holds all model weight tensors as `CudaSlice<f32>` on a single device,
 //! with shape metadata for downstream layers to query dimensions.
 
 #[cfg(feature = "cuda")]
@@ -13,43 +13,93 @@ mod inner {
     use rvllm_core::error::{LLMError, Result};
     use tracing::debug;
 
-    /// Container holding all model weights as f16 CUDA device buffers.
+    /// Container holding all model weights as typed CUDA device buffers.
+    ///
+    /// Each weight is stored as a `CudaSlice<f32>` alongside its shape.
+    /// When `use_fp16` is enabled, projection weights are also stored as
+    /// `CudaSlice<f16>` in `weights_f16` for half-precision GEMM.
     pub struct GpuModelWeights {
-        weights: HashMap<String, CudaSlice<f16>>,
+        weights: HashMap<String, CudaSlice<f32>>,
+        weights_f16: HashMap<String, CudaSlice<f16>>,
+        weights_u8: HashMap<String, Vec<u8>>,
         shapes: HashMap<String, Vec<usize>>,
     }
 
     impl GpuModelWeights {
-        /// Build from pre-loaded f16 weight maps.
+        /// Build from pre-loaded weight maps (typically produced by `gpu_loader::load_weights_to_gpu`).
         pub fn new(
-            weights: HashMap<String, CudaSlice<f16>>,
+            weights: HashMap<String, CudaSlice<f32>>,
             shapes: HashMap<String, Vec<usize>>,
         ) -> Self {
-            debug!(num_weights = weights.len(), "GpuModelWeights created (f16)");
-            Self { weights, shapes }
+            debug!(num_weights = weights.len(), "GpuModelWeights created");
+            Self {
+                weights,
+                weights_f16: HashMap::new(),
+                weights_u8: HashMap::new(),
+                shapes,
+            }
         }
 
-        /// Build an empty container.
+        /// Build an empty container, useful for tests or incremental loading.
         pub fn empty() -> Self {
             Self {
                 weights: HashMap::new(),
+                weights_f16: HashMap::new(),
+                weights_u8: HashMap::new(),
                 shapes: HashMap::new(),
             }
         }
 
-        /// Insert a single f16 weight tensor with its shape.
-        pub fn insert(&mut self, name: String, data: CudaSlice<f16>, shape: Vec<usize>) {
+        /// Insert a single weight tensor with its shape.
+        pub fn insert(&mut self, name: String, data: CudaSlice<f32>, shape: Vec<usize>) {
             self.shapes.insert(name.clone(), shape);
             self.weights.insert(name, data);
         }
 
+        /// Insert a single f16 weight tensor with its shape.
+        pub fn insert_f16(&mut self, name: String, data: CudaSlice<f16>, shape: Vec<usize>) {
+            self.shapes.insert(name.clone(), shape);
+            self.weights_f16.insert(name, data);
+        }
+
+        /// Insert a raw host-side U8 tensor with its shape.
+        pub fn insert_u8(&mut self, name: String, data: Vec<u8>, shape: Vec<usize>) {
+            self.shapes.insert(name.clone(), shape);
+            self.weights_u8.insert(name, data);
+        }
+
         /// Look up a weight by name.
-        pub fn get(&self, name: &str) -> Option<&CudaSlice<f16>> {
+        pub fn get(&self, name: &str) -> Option<&CudaSlice<f32>> {
             self.weights.get(name)
         }
 
+        /// Look up an f16 weight by name.
+        pub fn get_f16(&self, name: &str) -> Option<&CudaSlice<f16>> {
+            self.weights_f16.get(name)
+        }
+
+        /// Look up a host-side U8 tensor by name.
+        pub fn get_u8(&self, name: &str) -> Option<&[u8]> {
+            self.weights_u8.get(name).map(|v| v.as_slice())
+        }
+
+        /// Remove an f32 weight tensor, returning ownership if it existed.
+        pub fn remove(&mut self, name: &str) -> Option<CudaSlice<f32>> {
+            self.weights.remove(name)
+        }
+
+        /// Remove an f16 weight tensor, returning ownership if it existed.
+        pub fn remove_f16(&mut self, name: &str) -> Option<CudaSlice<f16>> {
+            self.weights_f16.remove(name)
+        }
+
+        /// Remove a host-side u8 tensor, returning ownership if it existed.
+        pub fn remove_u8(&mut self, name: &str) -> Option<Vec<u8>> {
+            self.weights_u8.remove(name)
+        }
+
         /// Look up a weight by name, returning an error if missing.
-        pub fn require(&self, name: &str) -> Result<&CudaSlice<f16>> {
+        pub fn require(&self, name: &str) -> Result<&CudaSlice<f32>> {
             self.weights
                 .get(name)
                 .ok_or_else(|| LLMError::GpuError(format!("weight not found: {}", name)))
@@ -70,30 +120,39 @@ mod inner {
 
         /// Number of weight tensors stored.
         pub fn num_weights(&self) -> usize {
-            self.weights.len()
+            self.weights.len() + self.weights_f16.len() + self.weights_u8.len()
         }
 
         /// Iterate over all weight names.
         pub fn names(&self) -> impl Iterator<Item = &str> {
-            self.weights.keys().map(|s| s.as_str())
+            self.weights
+                .keys()
+                .chain(self.weights_f16.keys())
+                .chain(self.weights_u8.keys())
+                .map(|s| s.as_str())
         }
 
         /// Check whether a weight exists.
         pub fn contains(&self, name: &str) -> bool {
             self.weights.contains_key(name)
+                || self.weights_f16.contains_key(name)
+                || self.weights_u8.contains_key(name)
         }
 
         /// Total GPU memory used by all weight buffers, in bytes.
         pub fn total_bytes(&self) -> usize {
             self.weights
                 .values()
-                .map(|s| s.len() * std::mem::size_of::<f16>())
+                .map(|s| s.len() * std::mem::size_of::<f32>())
                 .sum()
         }
 
-        /// Build from a host-side f16 weight map by uploading each tensor to GPU.
+        /// Build from a host-side weight map by uploading each tensor to GPU.
+        ///
+        /// Takes a `HashMap<String, Vec<f32>>` plus shapes, and copies every
+        /// tensor to the given CUDA stream via `clone_htod`.
         pub fn from_host(
-            host_weights: HashMap<String, Vec<f16>>,
+            host_weights: HashMap<String, Vec<f32>>,
             shapes: HashMap<String, Vec<usize>>,
             stream: &Arc<CudaStream>,
         ) -> Result<Self> {
@@ -106,16 +165,18 @@ mod inner {
             }
             debug!(
                 num_weights = gpu_weights.len(),
-                "GpuModelWeights uploaded from host (f16)"
+                "GpuModelWeights uploaded from host"
             );
             Ok(Self {
                 weights: gpu_weights,
+                weights_f16: HashMap::new(),
+                weights_u8: HashMap::new(),
                 shapes,
             })
         }
 
         /// Consume the container and return the underlying maps.
-        pub fn into_parts(self) -> (HashMap<String, CudaSlice<f16>>, HashMap<String, Vec<usize>>) {
+        pub fn into_parts(self) -> (HashMap<String, CudaSlice<f32>>, HashMap<String, Vec<usize>>) {
             (self.weights, self.shapes)
         }
     }
@@ -126,6 +187,11 @@ pub use inner::GpuModelWeights;
 
 #[cfg(test)]
 mod tests {
+    // GpuModelWeights requires a CUDA device for meaningful tests.
+    // Compile-time gated tests run with `cargo test --features cuda`.
+    // The public API surface (get, shape, require, etc.) is exercised
+    // there. Under default features we verify the module compiles.
+
     #[test]
     fn module_compiles() {
         assert!(true);

--- a/crates/rvllm-model-runner/src/gpu_layer.rs
+++ b/crates/rvllm-model-runner/src/gpu_layer.rs
@@ -1,4 +1,16 @@
-//! GPU Transformer Layer -- one complete transformer block on CUDA (f16 only).
+//! GPU Transformer Layer -- one complete transformer block on CUDA.
+//!
+//! Combines all CUDA dispatch ops (Agents 2-7) into the standard
+//! decoder-only transformer sequence:
+//!
+//! 1. RMSNorm(input)
+//! 2. QKV projection (cuBLAS sgemm)
+//! 3. RoPE on Q, K
+//! 4. PagedAttention(Q, K_cache, V_cache)
+//! 5. Output projection (cuBLAS sgemm)
+//! 6. RMSNorm(residual + attn_out)
+//! 7. MLP: gate+up (cuBLAS) -> fused_silu_mul -> down (cuBLAS)
+//! 8. residual + mlp_out
 //!
 //! All code is gated behind `#[cfg(feature = "cuda")]`.
 
@@ -6,13 +18,20 @@
 mod inner {
     use std::sync::Arc;
 
-    use cudarc::driver::{CudaFunction, CudaSlice, CudaStream, CudaView, CudaViewMut, DevicePtrMut, DeviceSlice, LaunchConfig, PushKernelArg};
+    use cudarc::driver::{CudaSlice, CudaStream, DeviceSlice, LaunchConfig, PushKernelArg};
     use half::f16;
     use tracing::{info, trace};
 
     use rvllm_core::error::{LLMError, Result};
     use rvllm_gpu::cublas::CublasHandle;
     use rvllm_gpu::kernel_loader::KernelLoader;
+
+    const GPT_OSS_SWIGLU_ALPHA: f32 = 1.702;
+    const GPT_OSS_SWIGLU_LIMIT: f32 = 7.0;
+    const GPT_OSS_MAX_TOP_K: usize = 8;
+    const MXFP4_VALUES: [f32; 16] = [
+        0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0, -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0,
+    ];
 
     /// Configuration for a single transformer layer.
     #[derive(Debug, Clone)]
@@ -26,48 +45,549 @@ mod inner {
         pub layer_idx: usize,
     }
 
-    /// Weight references for a single transformer layer (all f16).
+    /// Weight references for a single transformer layer.
     ///
     /// All slices live on GPU and are owned by the GpuModelWeights container.
     /// This struct borrows them for the duration of a forward pass.
     pub struct GpuLayerWeights<'a> {
         // Pre-attention norm
-        pub input_layernorm: &'a CudaSlice<f16>,
+        pub input_layernorm: &'a CudaSlice<f32>,
         // Attention projections
+        pub q_proj: &'a CudaSlice<f32>,
+        pub k_proj: &'a CudaSlice<f32>,
+        pub v_proj: &'a CudaSlice<f32>,
+        pub o_proj: &'a CudaSlice<f32>,
+        // Optional QKV biases (Qwen2.5 has these)
+        pub q_proj_bias: Option<&'a CudaSlice<f32>>,
+        pub k_proj_bias: Option<&'a CudaSlice<f32>>,
+        pub v_proj_bias: Option<&'a CudaSlice<f32>>,
+        // Post-attention norm
+        pub post_attention_layernorm: &'a CudaSlice<f32>,
+        // MLP weights
+        pub gate_proj: Option<&'a CudaSlice<f32>>,
+        pub up_proj: Option<&'a CudaSlice<f32>>,
+        pub down_proj: Option<&'a CudaSlice<f32>>,
+        pub gpt_oss_moe: Option<&'a GptOssMoeLayerWeights>,
+    }
+
+    /// FP16 weight references for a single transformer layer (f16 GEMM path).
+    ///
+    /// Projection weights are f16 (used with hgemm). Norm weights and biases
+    /// remain f32 since RMSNorm and bias-add operate in f32.
+    pub struct GpuLayerWeightsF16<'a> {
+        pub input_layernorm: &'a CudaSlice<f32>,
         pub q_proj: &'a CudaSlice<f16>,
         pub k_proj: &'a CudaSlice<f16>,
         pub v_proj: &'a CudaSlice<f16>,
         pub o_proj: &'a CudaSlice<f16>,
-        // Post-attention norm
-        pub post_attention_layernorm: &'a CudaSlice<f16>,
-        // MLP weights
-        pub gate_proj: &'a CudaSlice<f16>,
-        pub up_proj: &'a CudaSlice<f16>,
-        pub down_proj: &'a CudaSlice<f16>,
-        /// Fused QKV weight: [q_dim + kv_dim + kv_dim, hidden]. None if not fused.
-        pub fused_qkv: Option<&'a CudaSlice<f16>>,
-        /// Fused gate+up weight: [intermediate*2, hidden]. None if not fused.
-        pub fused_gate_up: Option<&'a CudaSlice<f16>>,
-        /// Fused QKV bias (f16). None if model has no QKV bias.
-        pub qkv_bias: Option<&'a CudaSlice<f16>>,
+        pub q_proj_bias: Option<&'a CudaSlice<f32>>,
+        pub k_proj_bias: Option<&'a CudaSlice<f32>>,
+        pub v_proj_bias: Option<&'a CudaSlice<f32>>,
+        pub post_attention_layernorm: &'a CudaSlice<f32>,
+        pub gate_proj: Option<&'a CudaSlice<f16>>,
+        pub up_proj: Option<&'a CudaSlice<f16>>,
+        pub down_proj: Option<&'a CudaSlice<f16>>,
+        pub gpt_oss_moe: Option<&'a GptOssMoeLayerWeights>,
+    }
+
+    /// Host-side GPT-OSS routed-expert weights. The CUDA runner keeps the
+    /// transformer shell on device and calls back to this CPU path for the
+    /// MXFP4 expert projections until a native kernel exists.
+    pub struct GptOssMoeLayerWeights {
+        pub router_weight: Vec<f32>,
+        pub router_bias: Vec<f32>,
+        pub gate_up_blocks: Vec<u8>,
+        pub gate_up_scales: Vec<u8>,
+        pub gate_up_bias: Vec<f32>,
+        pub down_blocks: Vec<u8>,
+        pub down_scales: Vec<u8>,
+        pub down_bias: Vec<f32>,
+        pub hidden_size: usize,
+        pub intermediate_size: usize,
+        pub num_local_experts: usize,
+        pub num_experts_per_tok: usize,
+        pub router_weight_gpu: Option<CudaSlice<f32>>,
+        pub router_bias_gpu: Option<CudaSlice<f32>>,
+        pub gate_up_blocks_gpu: Option<CudaSlice<u8>>,
+        pub gate_up_scales_gpu: Option<CudaSlice<u8>>,
+        pub gate_up_bias_gpu: Option<Vec<CudaSlice<f32>>>,
+        pub down_blocks_gpu: Option<CudaSlice<u8>>,
+        pub down_scales_gpu: Option<CudaSlice<u8>>,
+        pub down_bias_gpu: Option<Vec<CudaSlice<f32>>>,
+    }
+
+    impl GptOssMoeLayerWeights {
+        pub fn forward(
+            &self,
+            stream: &Arc<CudaStream>,
+            input: &CudaSlice<f32>,
+        ) -> Result<CudaSlice<f32>> {
+            let host_input = stream
+                .clone_dtoh(input)
+                .map_err(|e| LLMError::GpuError(format!("gpt-oss moe DtoH failed: {e}")))?;
+            let num_tokens = host_input.len() / self.hidden_size;
+            let mut output = vec![0.0f32; num_tokens * self.hidden_size];
+            let top_k = self.num_experts_per_tok.min(self.num_local_experts);
+
+            if top_k == 0 {
+                return stream
+                    .clone_htod(&output)
+                    .map_err(|e| LLMError::GpuError(format!("gpt-oss moe HtoD failed: {e}")));
+            }
+
+            for token_idx in 0..num_tokens {
+                let input_offset = token_idx * self.hidden_size;
+                let token = &host_input[input_offset..input_offset + self.hidden_size];
+
+                let mut logits = vec![0.0f32; self.num_local_experts];
+                for (expert_idx, logit) in logits.iter_mut().enumerate() {
+                    let row = expert_idx * self.hidden_size;
+                    let mut acc = self.router_bias[expert_idx];
+                    for hidden_idx in 0..self.hidden_size {
+                        acc += token[hidden_idx] * self.router_weight[row + hidden_idx];
+                    }
+                    *logit = acc;
+                }
+
+                let top_indices = top_k_indices(&logits, top_k);
+                let top_logits: Vec<f32> = top_indices.iter().map(|&idx| logits[idx]).collect();
+                let route_weights = softmax(&top_logits);
+
+                for (rank, &expert_idx) in top_indices.iter().enumerate() {
+                    let expert_out = self.forward_expert(expert_idx, token);
+                    let dst_offset = token_idx * self.hidden_size;
+                    let route_weight = route_weights[rank];
+                    for hidden_idx in 0..self.hidden_size {
+                        output[dst_offset + hidden_idx] += expert_out[hidden_idx] * route_weight;
+                    }
+                }
+            }
+
+            stream
+                .clone_htod(&output)
+                .map_err(|e| LLMError::GpuError(format!("gpt-oss moe HtoD failed: {e}")))
+        }
+
+        pub fn supports_gpu_decode(&self) -> bool {
+            self.router_weight_gpu.is_some()
+                && self.router_bias_gpu.is_some()
+                && self.gate_up_blocks_gpu.is_some()
+                && self.gate_up_scales_gpu.is_some()
+                && self.gate_up_bias_gpu.is_some()
+                && self.down_blocks_gpu.is_some()
+                && self.down_scales_gpu.is_some()
+                && self.down_bias_gpu.is_some()
+        }
+
+        pub fn forward_decode_gpu(
+            &self,
+            stream: &Arc<CudaStream>,
+            loader: &KernelLoader,
+            blas: &CublasHandle,
+            input: &CudaSlice<f32>,
+            num_tokens: usize,
+        ) -> Result<CudaSlice<f32>> {
+            if self.num_experts_per_tok == 0 || self.num_local_experts == 0 {
+                return stream
+                    .alloc_zeros::<f32>(num_tokens * self.hidden_size)
+                    .map_err(|e| LLMError::GpuError(format!("gpt-oss moe zero alloc: {e}")));
+            }
+            if self.num_experts_per_tok > GPT_OSS_MAX_TOP_K {
+                return Err(LLMError::GpuError(format!(
+                    "gpt-oss top-k {} exceeds kernel limit {}",
+                    self.num_experts_per_tok, GPT_OSS_MAX_TOP_K
+                )));
+            }
+
+            let router_weight_gpu = self.router_weight_gpu.as_ref().ok_or_else(|| {
+                LLMError::GpuError("missing GPU router weight for GPT-OSS decode".into())
+            })?;
+            let router_bias_gpu = self.router_bias_gpu.as_ref().ok_or_else(|| {
+                LLMError::GpuError("missing GPU router bias for GPT-OSS decode".into())
+            })?;
+            let gate_up_blocks_gpu = self.gate_up_blocks_gpu.as_ref().ok_or_else(|| {
+                LLMError::GpuError("missing GPU gate_up blocks for GPT-OSS decode".into())
+            })?;
+            let gate_up_scales_gpu = self.gate_up_scales_gpu.as_ref().ok_or_else(|| {
+                LLMError::GpuError("missing GPU gate_up scales for GPT-OSS decode".into())
+            })?;
+            let gate_up_bias_gpu = self.gate_up_bias_gpu.as_ref().ok_or_else(|| {
+                LLMError::GpuError("missing GPU gate_up bias for GPT-OSS decode".into())
+            })?;
+            let down_blocks_gpu = self.down_blocks_gpu.as_ref().ok_or_else(|| {
+                LLMError::GpuError("missing GPU down blocks for GPT-OSS decode".into())
+            })?;
+            let down_scales_gpu = self.down_scales_gpu.as_ref().ok_or_else(|| {
+                LLMError::GpuError("missing GPU down scales for GPT-OSS decode".into())
+            })?;
+            let down_bias_gpu = self.down_bias_gpu.as_ref().ok_or_else(|| {
+                LLMError::GpuError("missing GPU down bias for GPT-OSS decode".into())
+            })?;
+
+            let mut router_logits = GpuTransformerLayer::linear(
+                stream,
+                blas,
+                input,
+                router_weight_gpu,
+                num_tokens,
+                self.num_local_experts,
+                self.hidden_size,
+            )?;
+            GpuTransformerLayer::add_bias(
+                stream,
+                loader,
+                &mut router_logits,
+                router_bias_gpu,
+                num_tokens,
+                self.num_local_experts,
+            )?;
+
+            let mut topk_indices = stream
+                .alloc_zeros::<i32>(num_tokens * self.num_experts_per_tok)
+                .map_err(|e| LLMError::GpuError(format!("gpt-oss topk idx alloc: {e}")))?;
+            let mut topk_weights = stream
+                .alloc_zeros::<f32>(num_tokens * self.num_experts_per_tok)
+                .map_err(|e| LLMError::GpuError(format!("gpt-oss topk weights alloc: {e}")))?;
+            self.launch_route_topk(
+                stream,
+                loader,
+                &router_logits,
+                &mut topk_indices,
+                &mut topk_weights,
+                num_tokens,
+            )?;
+
+            let mut output = stream
+                .alloc_zeros::<f32>(num_tokens * self.hidden_size)
+                .map_err(|e| LLMError::GpuError(format!("gpt-oss moe output alloc: {e}")))?;
+
+            for expert_idx in 0..self.num_local_experts {
+                let mut route_weights = stream
+                    .alloc_zeros::<f32>(num_tokens)
+                    .map_err(|e| LLMError::GpuError(format!("gpt-oss route weights alloc: {e}")))?;
+                let mut masked_input = stream
+                    .alloc_zeros::<f32>(num_tokens * self.hidden_size)
+                    .map_err(|e| LLMError::GpuError(format!("gpt-oss masked input alloc: {e}")))?;
+                self.launch_select_inputs(
+                    stream,
+                    loader,
+                    input,
+                    &topk_indices,
+                    &topk_weights,
+                    &mut masked_input,
+                    &mut route_weights,
+                    num_tokens,
+                    expert_idx,
+                )?;
+
+                let mut gate_up_weight = stream
+                    .alloc_zeros::<f16>(self.intermediate_size * 2 * self.hidden_size)
+                    .map_err(|e| LLMError::GpuError(format!("gpt-oss gate_up weight alloc: {e}")))?;
+                self.launch_dequant_expert(
+                    stream,
+                    loader,
+                    gate_up_blocks_gpu,
+                    gate_up_scales_gpu,
+                    &mut gate_up_weight,
+                    expert_idx,
+                    self.intermediate_size * 2,
+                    self.hidden_size,
+                )?;
+                let mut gate_up = crate::layers::linear_cuda::CudaLinearLayer::forward_mixed(
+                    &masked_input,
+                    &gate_up_weight,
+                    num_tokens,
+                    self.intermediate_size * 2,
+                    self.hidden_size,
+                    blas,
+                    loader,
+                )?;
+                GpuTransformerLayer::add_bias(
+                    stream,
+                    loader,
+                    &mut gate_up,
+                    &gate_up_bias_gpu[expert_idx],
+                    num_tokens,
+                    self.intermediate_size * 2,
+                )?;
+                let fused = GpuTransformerLayer::fused_silu_mul_split(
+                    stream,
+                    loader,
+                    &gate_up,
+                    num_tokens * self.intermediate_size,
+                )?;
+
+                let mut down_weight = stream
+                    .alloc_zeros::<f16>(self.hidden_size * self.intermediate_size)
+                    .map_err(|e| LLMError::GpuError(format!("gpt-oss down weight alloc: {e}")))?;
+                self.launch_dequant_expert(
+                    stream,
+                    loader,
+                    down_blocks_gpu,
+                    down_scales_gpu,
+                    &mut down_weight,
+                    expert_idx,
+                    self.hidden_size,
+                    self.intermediate_size,
+                )?;
+                let mut expert_out = crate::layers::linear_cuda::CudaLinearLayer::forward_mixed(
+                    &fused,
+                    &down_weight,
+                    num_tokens,
+                    self.hidden_size,
+                    self.intermediate_size,
+                    blas,
+                    loader,
+                )?;
+                GpuTransformerLayer::add_bias(
+                    stream,
+                    loader,
+                    &mut expert_out,
+                    &down_bias_gpu[expert_idx],
+                    num_tokens,
+                    self.hidden_size,
+                )?;
+                self.launch_weighted_add(
+                    stream,
+                    loader,
+                    &mut output,
+                    &expert_out,
+                    &route_weights,
+                    num_tokens,
+                )?;
+            }
+
+            Ok(output)
+        }
+
+        pub(crate) fn forward_expert(&self, expert_idx: usize, input: &[f32]) -> Vec<f32> {
+            let gate_up = self.quantized_projection(
+                expert_idx,
+                input,
+                &self.gate_up_blocks,
+                &self.gate_up_scales,
+                &self.gate_up_bias,
+                self.intermediate_size * 2,
+                self.hidden_size,
+            );
+            let activated = apply_gpt_oss_swiglu(&gate_up, self.intermediate_size);
+            self.quantized_projection(
+                expert_idx,
+                &activated,
+                &self.down_blocks,
+                &self.down_scales,
+                &self.down_bias,
+                self.hidden_size,
+                self.intermediate_size,
+            )
+        }
+
+        fn quantized_projection(
+            &self,
+            expert_idx: usize,
+            input: &[f32],
+            blocks: &[u8],
+            scales: &[u8],
+            bias: &[f32],
+            out_features: usize,
+            in_features: usize,
+        ) -> Vec<f32> {
+            let groups = in_features.div_ceil(32);
+            let expert_blocks_stride = out_features * groups * 16;
+            let expert_scales_stride = out_features * groups;
+            let expert_bias_stride = out_features;
+
+            let mut output = vec![0.0f32; out_features];
+            let blocks_base = expert_idx * expert_blocks_stride;
+            let scales_base = expert_idx * expert_scales_stride;
+            let bias_base = expert_idx * expert_bias_stride;
+
+            for out_idx in 0..out_features {
+                let mut acc = bias[bias_base + out_idx];
+                let row_blocks = blocks_base + out_idx * groups * 16;
+                let row_scales = scales_base + out_idx * groups;
+
+                for group_idx in 0..groups {
+                    let scale = decode_mxfp_scale(scales[row_scales + group_idx]);
+                    let block_offset = row_blocks + group_idx * 16;
+                    let input_offset = group_idx * 32;
+                    for packed_idx in 0..16 {
+                        let packed = blocks[block_offset + packed_idx];
+                        let input_idx0 = input_offset + packed_idx * 2;
+                        if input_idx0 < in_features {
+                            acc += input[input_idx0] * MXFP4_VALUES[(packed & 0x0F) as usize] * scale;
+                        }
+                        let input_idx1 = input_idx0 + 1;
+                        if input_idx1 < in_features {
+                            acc += input[input_idx1] * MXFP4_VALUES[(packed >> 4) as usize] * scale;
+                        }
+                    }
+                }
+
+                output[out_idx] = acc;
+            }
+
+            output
+        }
+
+        fn launch_route_topk(
+            &self,
+            stream: &Arc<CudaStream>,
+            loader: &KernelLoader,
+            router_logits: &CudaSlice<f32>,
+            topk_indices: &mut CudaSlice<i32>,
+            topk_weights: &mut CudaSlice<f32>,
+            num_tokens: usize,
+        ) -> Result<()> {
+            let kernel = loader.get_func("gpt_oss_moe", "gpt_oss_route_topk_kernel")?;
+            let cfg = LaunchConfig {
+                grid_dim: (num_tokens as u32, 1, 1),
+                block_dim: (32, 1, 1),
+                shared_mem_bytes: 0,
+            };
+            let num_experts = self.num_local_experts as i32;
+            let top_k = self.num_experts_per_tok as i32;
+            unsafe {
+                stream
+                    .launch_builder(&kernel)
+                    .arg(router_logits)
+                    .arg(topk_indices)
+                    .arg(topk_weights)
+                    .arg(&num_experts)
+                    .arg(&top_k)
+                    .launch(cfg)
+                    .map_err(|e| LLMError::GpuError(format!("gpt-oss route topk launch: {e}")))?;
+            }
+            Ok(())
+        }
+
+        #[allow(clippy::too_many_arguments)]
+        fn launch_select_inputs(
+            &self,
+            stream: &Arc<CudaStream>,
+            loader: &KernelLoader,
+            input: &CudaSlice<f32>,
+            topk_indices: &CudaSlice<i32>,
+            topk_weights: &CudaSlice<f32>,
+            masked_input: &mut CudaSlice<f32>,
+            route_weights: &mut CudaSlice<f32>,
+            num_tokens: usize,
+            expert_idx: usize,
+        ) -> Result<()> {
+            let kernel = loader.get_func("gpt_oss_moe", "gpt_oss_select_expert_inputs_kernel")?;
+            let cfg = LaunchConfig {
+                grid_dim: (num_tokens as u32, 1, 1),
+                block_dim: (256, 1, 1),
+                shared_mem_bytes: std::mem::size_of::<f32>() as u32,
+            };
+            let hidden_size = self.hidden_size as i32;
+            let top_k = self.num_experts_per_tok as i32;
+            let expert_idx = expert_idx as i32;
+            unsafe {
+                stream
+                    .launch_builder(&kernel)
+                    .arg(masked_input)
+                    .arg(route_weights)
+                    .arg(input)
+                    .arg(topk_indices)
+                    .arg(topk_weights)
+                    .arg(&hidden_size)
+                    .arg(&top_k)
+                    .arg(&expert_idx)
+                    .launch(cfg)
+                    .map_err(|e| LLMError::GpuError(format!("gpt-oss select inputs launch: {e}")))?;
+            }
+            Ok(())
+        }
+
+        #[allow(clippy::too_many_arguments)]
+        fn launch_dequant_expert(
+            &self,
+            stream: &Arc<CudaStream>,
+            loader: &KernelLoader,
+            blocks: &CudaSlice<u8>,
+            scales: &CudaSlice<u8>,
+            output: &mut CudaSlice<f16>,
+            expert_idx: usize,
+            out_features: usize,
+            in_features: usize,
+        ) -> Result<()> {
+            let kernel = loader.get_func("gpt_oss_moe", "gpt_oss_dequant_expert_f16_kernel")?;
+            let total = out_features * in_features;
+            let threads = 256u32;
+            let blocks_grid = (total as u32).div_ceil(threads);
+            let cfg = LaunchConfig {
+                grid_dim: (blocks_grid, 1, 1),
+                block_dim: (threads, 1, 1),
+                shared_mem_bytes: 0,
+            };
+            let expert_idx = expert_idx as i32;
+            let out_features = out_features as i32;
+            let in_features = in_features as i32;
+            unsafe {
+                stream
+                    .launch_builder(&kernel)
+                    .arg(output)
+                    .arg(blocks)
+                    .arg(scales)
+                    .arg(&expert_idx)
+                    .arg(&out_features)
+                    .arg(&in_features)
+                    .launch(cfg)
+                    .map_err(|e| LLMError::GpuError(format!("gpt-oss dequant launch: {e}")))?;
+            }
+            Ok(())
+        }
+
+        fn launch_weighted_add(
+            &self,
+            stream: &Arc<CudaStream>,
+            loader: &KernelLoader,
+            output: &mut CudaSlice<f32>,
+            expert_out: &CudaSlice<f32>,
+            route_weights: &CudaSlice<f32>,
+            num_tokens: usize,
+        ) -> Result<()> {
+            let kernel = loader.get_func("gpt_oss_moe", "gpt_oss_weighted_add_kernel")?;
+            let total = num_tokens * self.hidden_size;
+            let threads = 256u32;
+            let blocks = (total as u32).div_ceil(threads);
+            let cfg = LaunchConfig {
+                grid_dim: (blocks, 1, 1),
+                block_dim: (threads, 1, 1),
+                shared_mem_bytes: 0,
+            };
+            let hidden_size = self.hidden_size as i32;
+            unsafe {
+                stream
+                    .launch_builder(&kernel)
+                    .arg(output)
+                    .arg(expert_out)
+                    .arg(route_weights)
+                    .arg(&hidden_size)
+                    .launch(cfg)
+                    .map_err(|e| LLMError::GpuError(format!("gpt-oss weighted add launch: {e}")))?;
+            }
+            Ok(())
+        }
     }
 
     /// Metadata needed for a single layer forward pass.
     pub struct GpuLayerInput<'a> {
-        /// Hidden states entering this layer, shape [num_tokens, hidden_size] (f16).
-        pub hidden_states: &'a CudaSlice<f16>,
+        /// Hidden states entering this layer, shape [num_tokens, hidden_size].
+        pub hidden_states: &'a CudaSlice<f32>,
         /// Position ids for RoPE, shape [num_tokens]. Kernels expect int*.
-        pub positions: CudaView<'a, i32>,
+        pub positions: &'a CudaSlice<i32>,
         /// KV cache key block for this layer (f16), shape [num_blocks, block_size, num_kv_heads, head_dim].
         pub key_cache: &'a CudaSlice<f16>,
         /// KV cache value block for this layer (f16), shape [num_blocks, block_size, num_kv_heads, head_dim].
         pub value_cache: &'a CudaSlice<f16>,
         /// Block table mapping sequence positions to cache blocks, shape [num_seqs, max_blocks_per_seq].
-        pub block_tables: CudaView<'a, i32>,
+        pub block_tables: &'a CudaSlice<i32>,
         /// Context length for each sequence, shape [num_seqs].
-        pub context_lens: CudaView<'a, i32>,
+        pub context_lens: &'a CudaSlice<i32>,
         /// Slot mapping for cache writes during prefill, shape [num_tokens].
-        pub slot_mapping: CudaView<'a, i32>,
+        pub slot_mapping: &'a CudaSlice<i32>,
         /// Number of tokens in the batch.
         pub num_tokens: usize,
         /// Number of sequences in the batch.
@@ -80,7 +600,7 @@ mod inner {
         pub is_prefill: bool,
         /// Per-sequence query token start positions: [num_seqs + 1] with sentinel.
         /// Built from actual query token counts, NOT context_lens.
-        pub seq_start_pos: CudaView<'a, i32>,
+        pub seq_start_pos: &'a CudaSlice<i32>,
         /// RoPE cos table on GPU: [max_position, head_dim/2].
         pub rope_cos: &'a CudaSlice<f32>,
         /// RoPE sin table on GPU: [max_position, head_dim/2].
@@ -107,38 +627,16 @@ mod inner {
         /// Returns the output hidden states as a new CudaSlice<f32> of shape
         /// [num_tokens, hidden_size]. The caller is responsible for using this
         /// as input to the next layer.
-        /// Fully f16 forward pass -- ZERO type casts within the layer.
-        /// All inputs, intermediates, and outputs are f16.
-        //   B) qkv [T*(Q+2K)] dead at step 5 -> reuse for gate_up [T*2I] at step 9
-        //      (qkv_dim ~ H+2*H/GQA_ratio, gate_up = 2*I; for llama 2I > qkv, but
-        //       qkv buf could be a prefix if gate_up scratch is sized to max(qkv,2I))
-        //   C) attn_out [T*Q] dead at step 7 -> reuse for fused/silu [T*I] at step 9
-        //      (I > Q typically, so need max(Q,I) sizing)
-        //   D) attn_proj [T*H] dead at step 8 -> reuse for mlp_out [T*H] at step 10
-        //      (exact same size)
-        //   E) normed2 [T*H] dead at step 9 -> reuse for mlp_out [T*H] at step 10
-        //      (exact same size, alternative to D)
-        //
-        // LOW-HANGING FRUIT (same size, zero waste):
-        //   1. attn_proj -> mlp_out  [both T*H, saves 1 alloc]
-        //   2. normed -> attn_out    [T*H vs T*Q, same when Q=H, saves 1 alloc]
-        //   3. normed2 is an alternative to attn_proj for mlp_out reuse
-        //
-        // With a single scratch buffer sized to max(T*qkv_dim, T*2I, T*H):
-        //   Could eliminate 4-5 allocs, reducing 10 -> 5-6 per layer.
-        // ==================================================================
-        /// Full f16 forward with cross-layer fusion support.
-        /// When `prev_mlp_out` is Some, fuses the previous layer's residual add
-        /// with this layer's pre-attention RMSNorm (1 kernel instead of 2).
-        /// Returns (residual, mlp_out) for the NEXT layer to fuse.
-        pub fn forward(
+        /// FP16 forward pass -- uses hgemm for projection weights (f16), while
+        /// norms, biases, RoPE, and attention remain in f32.
+        pub fn forward_f16(
             &self,
             input: &GpuLayerInput<'_>,
-            weights: &GpuLayerWeights<'_>,
+            weights: &GpuLayerWeightsF16<'_>,
             blas: &CublasHandle,
-            prev_mlp_out: Option<&CudaSlice<f16>>,
-            lt: Option<&crate::CublasLtRef>,
-        ) -> Result<(CudaSlice<f16>, CudaSlice<f16>)> {
+        ) -> Result<CudaSlice<f32>> {
+            use crate::layers::linear_cuda::CudaLinearLayer;
+
             let cfg = &self.config;
             let num_tokens = input.num_tokens;
             let hidden = cfg.hidden_size;
@@ -147,584 +645,586 @@ mod inner {
             let head_dim = cfg.head_dim;
             let intermediate = cfg.intermediate_size;
 
-            let hidden_f16 = input.hidden_states;
-            let norm_w = weights.input_layernorm;
-            let post_norm_w = weights.post_attention_layernorm;
-            let dbg = cfg.layer_idx < 1 && std::env::var("RVLLM_DEBUG").is_ok();
-            let dbg_dump = |label: &str, buf: &CudaSlice<f16>, stream: &Arc<CudaStream>| {
-                if let Ok(vals) = stream.clone_dtoh(buf) {
-                    let first5: Vec<f32> = vals.iter().take(5).map(|v| v.to_f32()).collect();
-                    let last5: Vec<f32> = vals.iter().rev().take(5).rev().map(|v| v.to_f32()).collect();
-                    let nan = vals.iter().any(|v| v.to_f32().is_nan());
-                    let max = vals.iter().map(|v| v.to_f32().abs()).fold(0.0f32, f32::max);
-                    let mean = vals.iter().map(|v| v.to_f32()).sum::<f32>() / vals.len() as f32;
-                    info!("DEBUG L0 {label}: first5={first5:?} last5={last5:?} max={max:.4} mean={mean:.6} nan={nan} len={}", vals.len());
-                }
-            };
+            // 1. Pre-attention RMSNorm (f32)
+            let normed = Self::rms_norm(
+                &self.stream,
+                &self.loader,
+                input.hidden_states,
+                weights.input_layernorm,
+                cfg.rms_norm_eps,
+                num_tokens,
+                hidden,
+            )?;
 
+            // 2. QKV projections via hgemm (f16 weights)
             let q_dim = num_heads * head_dim;
             let kv_dim = num_kv_heads * head_dim;
-            let qkv_dim = q_dim + kv_dim + kv_dim;
-            let q_end = num_tokens * q_dim;
-            let k_end = q_end + num_tokens * kv_dim;
 
-            // ================================================================
-            // T=1 DECODE: maximally fused path
-            // Fuses: add+norm+QKV GEMV, bias, RoPE+cache_write, attn, add+norm+gateup, silu+down
-            // ================================================================
-            if num_tokens == 1 && !input.is_prefill {
-                // --- Step 1+2: Fused add+norm+QKV GEMV or norm+QKV GEMV ---
-                let (mut qkv, residual_ref) = if let Some(prev_mlp) = prev_mlp_out {
-                    // Try fused add+norm+QKV GEMV (3-way: add + norm + projection)
-                    let fused_qkv_w = weights.fused_qkv.unwrap_or(weights.q_proj);
-                    if let Ok(ref fk) = self.loader.get_func("fused_add_norm_qkv", "fused_cute_add_norm_qkv_gemv") {
-                        let mut qkv_out = unsafe { self.stream.alloc::<f16>(qkv_dim) }
-                            .map_err(|e| LLMError::GpuError(format!("fused qkv alloc: {e}")))?;
-                        let mut residual_out = unsafe { self.stream.alloc::<f16>(hidden) }
-                            .map_err(|e| LLMError::GpuError(format!("fused residual alloc: {e}")))?;
-                        let smem = (hidden * 4 + 8 * 4) as u32;
-                        let rpb = 8u32;
-                        if smem > 49152 {
-                            fk.set_attribute(cudarc::driver::sys::CUfunction_attribute_enum::CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES, smem as i32)
-                                .map_err(|e| LLMError::GpuError(format!("smem attr: {e}")))?;
-                        }
-                        unsafe {
-                            self.stream.launch_builder(fk)
-                                .arg(&mut qkv_out).arg(&mut residual_out)
-                                .arg(hidden_f16).arg(prev_mlp).arg(norm_w).arg(fused_qkv_w)
-                                .arg(&cfg.rms_norm_eps).arg(&(hidden as i32)).arg(&(qkv_dim as i32))
-                                .launch(LaunchConfig { grid_dim: ((qkv_dim as u32 + rpb - 1) / rpb, 1, 1), block_dim: (256, 1, 1), shared_mem_bytes: smem })
-                                .map_err(|e| LLMError::GpuError(format!("fused add_norm_qkv: {e}")))?;
-                        }
-                        (qkv_out, residual_out)
-                    } else {
-                        // Fallback: separate add+norm then QKV
-                        let (normed, residual) = Self::fused_residual_rmsnorm_f16(
-                            &self.stream, &self.loader, hidden_f16, prev_mlp, norm_w,
-                            cfg.rms_norm_eps, num_tokens, hidden)?;
-                        let qkv = Self::hgemm_dispatch(&self.stream, blas, lt, &normed, fused_qkv_w, 1, qkv_dim, hidden, &self.loader)?;
-                        (qkv, residual)
-                    }
-                } else {
-                    // First layer: norm+QKV GEMV
-                    let fused_qkv_w = weights.fused_qkv.unwrap_or(weights.q_proj);
-                    if let Ok(ref fk) = self.loader.get_func("fused_norm_qkv", "fused_cute_norm_qkv_gemv") {
-                        let mut qkv_out = unsafe { self.stream.alloc::<f16>(qkv_dim) }
-                            .map_err(|e| LLMError::GpuError(format!("fused qkv alloc: {e}")))?;
-                        let smem = (hidden * 4 + 8 * 4) as u32;
-                        let rpb = 8u32;
-                        if smem > 49152 {
-                            fk.set_attribute(cudarc::driver::sys::CUfunction_attribute_enum::CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES, smem as i32)
-                                .map_err(|e| LLMError::GpuError(format!("smem attr: {e}")))?;
-                        }
-                        unsafe {
-                            self.stream.launch_builder(fk)
-                                .arg(&mut qkv_out).arg(hidden_f16).arg(norm_w).arg(fused_qkv_w)
-                                .arg(&cfg.rms_norm_eps).arg(&(hidden as i32)).arg(&(qkv_dim as i32))
-                                .launch(LaunchConfig { grid_dim: ((qkv_dim as u32 + rpb - 1) / rpb, 1, 1), block_dim: (256, 1, 1), shared_mem_bytes: smem })
-                                .map_err(|e| LLMError::GpuError(format!("fused norm_qkv: {e}")))?;
-                        }
-                        let residual = hidden_f16.clone();
-                        (qkv_out, residual)
-                    } else {
-                        let normed = Self::rms_norm_f16(&self.stream, &self.loader, hidden_f16, norm_w, cfg.rms_norm_eps, 1, hidden)?;
-                        let qkv = Self::hgemm_dispatch(&self.stream, blas, lt, &normed, fused_qkv_w, 1, qkv_dim, hidden, &self.loader)?;
-                        let residual = hidden_f16.clone();
-                        (qkv, residual)
-                    }
-                };
+            let mut q = CudaLinearLayer::forward_once_f16(
+                &normed, weights.q_proj, num_tokens, q_dim, hidden, blas, &self.loader,
+            )?;
+            let mut k = CudaLinearLayer::forward_once_f16(
+                &normed, weights.k_proj, num_tokens, kv_dim, hidden, blas, &self.loader,
+            )?;
+            let mut v = CudaLinearLayer::forward_once_f16(
+                &normed, weights.v_proj, num_tokens, kv_dim, hidden, blas, &self.loader,
+            )?;
 
-                // --- Step 3: QKV bias (if model has it) ---
-                if let Some(bias) = weights.qkv_bias {
-                    let mut qkv_view = qkv.slice_mut(..qkv_dim);
-                    Self::add_bias_f16_view(&self.stream, &self.loader, &mut qkv_view, bias, 1, qkv_dim)?;
-                }
-
-                // --- Step 4+5: Fused RoPE + KV cache write ---
-                if let Ok(ref fk) = self.loader.get_func("fused_rope_cache", "fused_rope_cache_f16_kernel") {
-                    let (mut q_part, mut kv_rest) = qkv.split_at_mut(q_dim);
-                    let (mut k_part, v_part) = kv_rest.split_at_mut(kv_dim);
-                    let v_view = v_part.slice(..kv_dim);
-                    let half_dim = head_dim / 2;
-                    let grid_y = num_heads.max(num_kv_heads) as u32;
-                    unsafe {
-                        self.stream.launch_builder(fk)
-                            .arg(&mut q_part).arg(&mut k_part).arg(&v_view)
-                            .arg(input.key_cache).arg(input.value_cache)
-                            .arg(input.rope_cos).arg(input.rope_sin)
-                            .arg(&input.positions).arg(&input.slot_mapping)
-                            .arg(&(num_tokens as i32)).arg(&(num_heads as i32))
-                            .arg(&(num_kv_heads as i32)).arg(&(head_dim as i32))
-                            .launch(LaunchConfig { grid_dim: (num_tokens as u32, grid_y, 1), block_dim: (half_dim.min(1024) as u32, 1, 1), shared_mem_bytes: 0 })
-                            .map_err(|e| LLMError::GpuError(format!("fused rope+cache: {e}")))?;
-                    }
-                } else {
-                    // Fallback: separate RoPE then cache write
-                    {
-                        let (mut q_part, mut kv_part) = qkv.split_at_mut(q_dim);
-                        let mut k_view = kv_part.slice_mut(..kv_dim);
-                        Self::apply_rotary_embedding_f16_views(
-                            &self.stream, &self.loader, &mut q_part, &mut k_view,
-                            &input.positions, input.rope_cos, input.rope_sin,
-                            num_tokens, num_heads, num_kv_heads, head_dim)?;
-                    }
-                    {
-                        let k_view = qkv.slice(q_dim..q_dim + kv_dim);
-                        let v_view = qkv.slice(q_dim + kv_dim..);
-                        Self::cache_write_f16_views(
-                            &self.stream, &self.loader, &k_view, &v_view,
-                            input.key_cache, input.value_cache, &input.slot_mapping,
-                            num_tokens, num_kv_heads, head_dim)?;
-                    }
-                }
-
-                // --- Step 6: Attention (FA3) ---
-                let attn_out = Self::decode_attention_f16io(
-                    &self.stream, &self.loader,
-                    &qkv.slice(..q_dim),
-                    input.key_cache, input.value_cache,
-                    &input.block_tables, &input.context_lens,
-                    1, input.num_seqs, num_heads, num_kv_heads, head_dim,
-                    input.max_context_len, input.block_size)?;
-
-                // --- Step 7: O projection ---
-                let attn_proj = Self::hgemm_dispatch(&self.stream, blas, lt, &attn_out, weights.o_proj, 1, hidden, q_dim, &self.loader)?;
-
-                // --- Steps 8-10: Fused add+norm+gateup + silu+down (already wired) ---
-                let (residual, mlp_out) = {
-                    let fused_gateup_ok = self.loader.get_func("fused_add_norm_gateup", "fused_cute_add_norm_gateup_gemv").ok();
-                    if let Some(ref fk) = fused_gateup_ok {
-                        let gate_up_dim = intermediate * 2;
-                        let mut gate_up_out = unsafe { self.stream.alloc::<f16>(gate_up_dim) }
-                            .map_err(|e| LLMError::GpuError(format!("fused gateup alloc: {e}")))?;
-                        let mut residual_out2 = unsafe { self.stream.alloc::<f16>(hidden) }
-                            .map_err(|e| LLMError::GpuError(format!("fused residual alloc: {e}")))?;
-                        let smem = (hidden * 4 + 8 * 4) as u32;
-                        let fused_gate_up_w = weights.fused_gate_up.unwrap_or(weights.gate_proj);
-                        let rpb = 8u32;
-                        if smem > 49152 {
-                            fk.set_attribute(cudarc::driver::sys::CUfunction_attribute_enum::CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES, smem as i32)
-                                .map_err(|e| LLMError::GpuError(format!("smem attr: {e}")))?;
-                        }
-                        unsafe {
-                            self.stream.launch_builder(fk)
-                                .arg(&mut gate_up_out).arg(&mut residual_out2)
-                                .arg(&residual_ref).arg(&attn_proj).arg(post_norm_w).arg(fused_gate_up_w)
-                                .arg(&cfg.rms_norm_eps).arg(&(hidden as i32)).arg(&(gate_up_dim as i32))
-                                .launch(LaunchConfig { grid_dim: ((gate_up_dim as u32 + rpb - 1) / rpb, 1, 1), block_dim: (256, 1, 1), shared_mem_bytes: smem })
-                                .map_err(|e| LLMError::GpuError(format!("fused add_norm_gateup: {e}")))?;
-                        }
-                        let gate = gate_up_out.slice(..intermediate);
-                        let up = gate_up_out.slice(intermediate..gate_up_dim);
-                        // Fused silu+down GEMV
-                        let mlp = if let Ok(ref sk) = self.loader.get_func("fused_silu_down", "fused_cute_silu_down_gemv") {
-                            let mut down_out = unsafe { self.stream.alloc::<f16>(hidden) }
-                                .map_err(|e| LLMError::GpuError(format!("fused silu_down alloc: {e}")))?;
-                            let sk_smem = (8 * 4) as u32;
-                            unsafe {
-                                self.stream.launch_builder(sk)
-                                    .arg(&mut down_out).arg(&gate).arg(&up).arg(weights.down_proj)
-                                    .arg(&(hidden as i32)).arg(&(intermediate as i32))
-                                    .launch(LaunchConfig { grid_dim: (((hidden as u32) + 7) / 8, 1, 1), block_dim: (256, 1, 1), shared_mem_bytes: sk_smem })
-                                    .map_err(|e| LLMError::GpuError(format!("fused silu_down: {e}")))?;
-                            }
-                            down_out
-                        } else {
-                            let fused_act = Self::fused_silu_mul_f16_split(&self.stream, &self.loader, &gate_up_out, intermediate)?;
-                            Self::hgemm_dispatch(&self.stream, blas, lt, &fused_act, weights.down_proj, 1, hidden, intermediate, &self.loader)?
-                        };
-                        (residual_out2, mlp)
-                    } else {
-                        let (normed2, residual2) = Self::fused_residual_rmsnorm_f16(
-                            &self.stream, &self.loader, &residual_ref, &attn_proj, post_norm_w,
-                            cfg.rms_norm_eps, 1, hidden)?;
-                        let gate_up = if let Some(fguw) = weights.fused_gate_up {
-                            Self::hgemm_dispatch(&self.stream, blas, lt, &normed2, fguw, 1, intermediate * 2, hidden, &self.loader)?
-                        } else {
-                            let g = Self::hgemm_dispatch(&self.stream, blas, lt, &normed2, weights.gate_proj, 1, intermediate, hidden, &self.loader)?;
-                            let u = Self::hgemm_dispatch(&self.stream, blas, lt, &normed2, weights.up_proj, 1, intermediate, hidden, &self.loader)?;
-                            let mut buf = unsafe { self.stream.alloc::<f16>(intermediate * 2) }
-                                .map_err(|e| LLMError::GpuError(format!("concat: {e}")))?;
-                            self.stream.memcpy_dtod(&g, &mut buf.slice_mut(..intermediate)).map_err(|e| LLMError::GpuError(format!("g: {e}")))?;
-                            self.stream.memcpy_dtod(&u, &mut buf.slice_mut(intermediate..)).map_err(|e| LLMError::GpuError(format!("u: {e}")))?;
-                            buf
-                        };
-                        let fused_act = Self::fused_silu_mul_f16_split(&self.stream, &self.loader, &gate_up, intermediate)?;
-                        let mlp = Self::hgemm_dispatch(&self.stream, blas, lt, &fused_act, weights.down_proj, 1, hidden, intermediate, &self.loader)?;
-                        (residual2, mlp)
-                    }
-                };
-                return Ok((residual, mlp_out));
+            // QKV biases (f32)
+            if let Some(bias) = weights.q_proj_bias {
+                Self::add_bias(&self.stream, &self.loader, &mut q, bias, num_tokens, q_dim)?;
+            }
+            if let Some(bias) = weights.k_proj_bias {
+                Self::add_bias(&self.stream, &self.loader, &mut k, bias, num_tokens, kv_dim)?;
+            }
+            if let Some(bias) = weights.v_proj_bias {
+                Self::add_bias(&self.stream, &self.loader, &mut v, bias, num_tokens, kv_dim)?;
             }
 
-            // ================================================================
-            // T>1 PREFILL: unfused path (cuBLAS GEMMs, separate kernels)
-            // ================================================================
+            // 3. RoPE
+            let (q_rot, k_rot) = Self::apply_rotary_embedding(
+                &self.stream,
+                &self.loader,
+                &q,
+                &k,
+                input.positions,
+                input.rope_cos,
+                input.rope_sin,
+                num_tokens,
+                num_heads,
+                num_kv_heads,
+                head_dim,
+            )?;
 
-            // 1. Pre-attention RMSNorm
-            let (normed, fused_residual) = if let Some(prev_mlp) = prev_mlp_out {
-                let (n, r) = Self::fused_residual_rmsnorm_f16(
-                    &self.stream, &self.loader, hidden_f16, prev_mlp, norm_w,
-                    cfg.rms_norm_eps, num_tokens, hidden)?;
-                (n, Some(r))
-            } else {
-                let n = Self::rms_norm_f16(&self.stream, &self.loader, hidden_f16, norm_w,
-                    cfg.rms_norm_eps, num_tokens, hidden)?;
-                (n, None)
-            };
-            let residual_ref = fused_residual.as_ref().unwrap_or(hidden_f16);
+            // 4. KV cache write + attention
+            Self::cache_write(
+                &self.stream,
+                &self.loader,
+                &k_rot,
+                &v,
+                input.key_cache,
+                input.value_cache,
+                input.slot_mapping,
+                num_tokens,
+                num_kv_heads,
+                head_dim,
+            )?;
 
-            // 2. QKV projections
-            // For N<=64: fused GEMM + transpose (saves 2 GEMM launches)
-            // For N>64: 3 separate GEMMs into slices (no transpose overhead)
-            let use_fused_qkv = weights.fused_qkv.is_some() && num_tokens <= 64;
-            let mut qkv = if use_fused_qkv {
-                let fused_qkv = weights.fused_qkv.unwrap();
-                let qkv_interleaved = Self::hgemm_dispatch(&self.stream, blas, lt, &normed, fused_qkv, num_tokens, qkv_dim, hidden, &self.loader)?;
-                if let Ok(transpose_fn) = self.loader.get_func("qkv_transpose", "qkv_transpose_f16_kernel") {
-                    let mut qkv_transposed = unsafe { self.stream.alloc::<f16>(num_tokens * qkv_dim) }
-                        .map_err(|e| LLMError::GpuError(format!("qkv transpose alloc: {e}")))?;
-                    let total = (num_tokens * qkv_dim) as u32;
-                    let cfg = LaunchConfig { grid_dim: ((total + 255) / 256, 1, 1), block_dim: (256, 1, 1), shared_mem_bytes: 0 };
-                    unsafe {
-                        self.stream.launch_builder(&transpose_fn)
-                            .arg(&mut qkv_transposed).arg(&qkv_interleaved)
-                            .arg(&(num_tokens as i32)).arg(&(q_dim as i32)).arg(&(kv_dim as i32))
-                            .launch(cfg)
-                            .map_err(|e| LLMError::GpuError(format!("qkv transpose: {e}")))?;
-                    }
-                    qkv_transposed
-                } else {
-                    let mut qkv_buf = unsafe { self.stream.alloc::<f16>(num_tokens * qkv_dim) }
-                        .map_err(|e| LLMError::GpuError(format!("qkv alloc: {e}")))?;
-                    let q_end_t = num_tokens * q_dim;
-                    let k_end_t = q_end_t + num_tokens * kv_dim;
-                    { let mut d = qkv_buf.slice_mut(..q_end_t); blas.hgemm_into(num_tokens, q_dim, hidden, 1.0, &normed, weights.q_proj, 0.0, &mut d)?; }
-                    { let mut d = qkv_buf.slice_mut(q_end_t..k_end_t); blas.hgemm_into(num_tokens, kv_dim, hidden, 1.0, &normed, weights.k_proj, 0.0, &mut d)?; }
-                    { let mut d = qkv_buf.slice_mut(k_end_t..); blas.hgemm_into(num_tokens, kv_dim, hidden, 1.0, &normed, weights.v_proj, 0.0, &mut d)?; }
-                    qkv_buf
-                }
-            } else {
-                let mut qkv_buf = unsafe { self.stream.alloc::<f16>(num_tokens * qkv_dim) }
-                    .map_err(|e| LLMError::GpuError(format!("qkv alloc: {e}")))?;
-                let q_end_t = num_tokens * q_dim;
-                let k_end_t = q_end_t + num_tokens * kv_dim;
-                { let mut d = qkv_buf.slice_mut(..q_end_t); blas.hgemm_into(num_tokens, q_dim, hidden, 1.0, &normed, weights.q_proj, 0.0, &mut d)?; }
-                { let mut d = qkv_buf.slice_mut(q_end_t..k_end_t); blas.hgemm_into(num_tokens, kv_dim, hidden, 1.0, &normed, weights.k_proj, 0.0, &mut d)?; }
-                { let mut d = qkv_buf.slice_mut(k_end_t..); blas.hgemm_into(num_tokens, kv_dim, hidden, 1.0, &normed, weights.v_proj, 0.0, &mut d)?; }
-                qkv_buf
-            };
-
-            // 3. QKV bias -- broadcast bias[qkv_dim] across N tokens in one kernel per section
-            if let Some(bias) = weights.qkv_bias {
-                if let Ok(ref bk) = self.loader.get_func("add_bias_broadcast", "add_bias_broadcast_f16_kernel") {
-                    // Q bias
-                    let mut q_view = qkv.slice_mut(..q_end);
-                    let q_bias = bias.slice(..q_dim);
-                    let q_total = (num_tokens * q_dim) as u32;
-                    unsafe {
-                        self.stream.launch_builder(bk)
-                            .arg(&mut q_view).arg(&q_bias).arg(&(num_tokens as i32)).arg(&(q_dim as i32))
-                            .launch(LaunchConfig { grid_dim: ((q_total + 255) / 256, 1, 1), block_dim: (256, 1, 1), shared_mem_bytes: 0 })
-                            .map_err(|e| LLMError::GpuError(format!("q bias: {e}")))?;
-                    }
-                    // K bias
-                    let mut k_view = qkv.slice_mut(q_end..k_end);
-                    let k_bias = bias.slice(q_dim..q_dim + kv_dim);
-                    let k_total = (num_tokens * kv_dim) as u32;
-                    unsafe {
-                        self.stream.launch_builder(bk)
-                            .arg(&mut k_view).arg(&k_bias).arg(&(num_tokens as i32)).arg(&(kv_dim as i32))
-                            .launch(LaunchConfig { grid_dim: ((k_total + 255) / 256, 1, 1), block_dim: (256, 1, 1), shared_mem_bytes: 0 })
-                            .map_err(|e| LLMError::GpuError(format!("k bias: {e}")))?;
-                    }
-                    // V bias
-                    let mut v_view = qkv.slice_mut(k_end..);
-                    let v_bias = bias.slice(q_dim + kv_dim..qkv_dim);
-                    unsafe {
-                        self.stream.launch_builder(bk)
-                            .arg(&mut v_view).arg(&v_bias).arg(&(num_tokens as i32)).arg(&(kv_dim as i32))
-                            .launch(LaunchConfig { grid_dim: ((k_total + 255) / 256, 1, 1), block_dim: (256, 1, 1), shared_mem_bytes: 0 })
-                            .map_err(|e| LLMError::GpuError(format!("v bias: {e}")))?;
-                    }
-                } else {
-                    // Fallback: old path
-                    { let mut v = qkv.slice_mut(..q_end); Self::add_bias_f16_view(&self.stream, &self.loader, &mut v, bias, num_tokens, q_dim)?; }
-                }
-            }
-
-            // 4. RoPE
-            {
-                let (mut q_part, mut kv_part) = qkv.split_at_mut(q_end);
-                let mut k_view = kv_part.slice_mut(..num_tokens * kv_dim);
-                Self::apply_rotary_embedding_f16_views(&self.stream, &self.loader,
-                    &mut q_part, &mut k_view, &input.positions, input.rope_cos, input.rope_sin,
-                    num_tokens, num_heads, num_kv_heads, head_dim)?;
-            }
-
-            // 5. KV cache write
-            {
-                let k_view = qkv.slice(q_end..k_end);
-                let v_view = qkv.slice(k_end..);
-                Self::cache_write_f16_views(&self.stream, &self.loader, &k_view, &v_view,
-                    input.key_cache, input.value_cache, &input.slot_mapping,
-                    num_tokens, num_kv_heads, head_dim)?;
-            }
-
-            // 6. Attention
             let attn_out = if input.is_prefill {
-                // Prefill uses f32 Q kernel (prefill is one-shot, not perf-critical)
-                // Fall back to f32 path for prefill: cast Q f16->f32, run f32 prefill, cast back
-                let cast_f16_f32 = self.loader.get_func("cast_fp", "cast_f16_to_f32_kernel")
-                    .map_err(|e| LLMError::GpuError(format!("load cast f16->f32: {e}")))?;
-                let cast_f32_f16 = self.loader.get_func("cast_fp", "cast_f32_to_f16_kernel")
-                    .map_err(|e| LLMError::GpuError(format!("load cast f32->f16: {e}")))?;
-                let q_f16 = qkv.slice(..q_end);
-                let q_f32 = Self::cast_f16_to_f32(&self.stream, &q_f16, q_end, &cast_f16_f32)?;
-                let attn_f32 = Self::prefill_attention(
-                    &self.stream, &self.loader,
-                    &q_f32.as_view(),
-                    input.key_cache, input.value_cache,
-                    &input.block_tables, &input.context_lens, &input.seq_start_pos,
-                    num_tokens, input.num_seqs, num_heads, num_kv_heads, head_dim,
-                    input.max_context_len, input.block_size,
-                )?;
-                Self::cast_f32_to_f16(&self.stream, &attn_f32, num_tokens * num_heads * head_dim, &cast_f32_f16)?
+                Self::prefill_attention(
+                    &self.stream,
+                    &self.loader,
+                    &q_rot,
+                    input.key_cache,
+                    input.value_cache,
+                    input.block_tables,
+                    input.context_lens,
+                    input.seq_start_pos,
+                    num_tokens,
+                    input.num_seqs,
+                    num_heads,
+                    num_kv_heads,
+                    head_dim,
+                    input.max_context_len,
+                    input.block_size,
+                )?
             } else {
-                Self::decode_attention_f16io(
-                    &self.stream, &self.loader,
-                    &qkv.slice(..q_end),
-                    input.key_cache, input.value_cache,
-                    &input.block_tables, &input.context_lens,
-                    num_tokens, input.num_seqs, num_heads, num_kv_heads, head_dim,
-                    input.max_context_len, input.block_size,
+                Self::decode_attention(
+                    &self.stream,
+                    &self.loader,
+                    &q_rot,
+                    input.key_cache,
+                    input.value_cache,
+                    input.block_tables,
+                    input.context_lens,
+                    num_tokens,
+                    input.num_seqs,
+                    num_heads,
+                    num_kv_heads,
+                    head_dim,
+                    input.max_context_len,
+                    input.block_size,
                 )?
             };
 
-            if dbg { dbg_dump("attn_out", &attn_out, &self.stream); }
+            // 5. Output projection (f16 weight)
+            let attn_proj = CudaLinearLayer::forward_once_f16(
+                &attn_out, weights.o_proj, num_tokens, hidden, q_dim, blas, &self.loader,
+            )?;
 
-            // 7. O projection (T>1 prefill path)
-            let attn_proj = Self::hgemm_dispatch(&self.stream, blas, lt, &attn_out, weights.o_proj, num_tokens, hidden, q_dim, &self.loader)?;
+            // Residual
+            let residual = Self::add_tensors(
+                &self.stream,
+                &self.loader,
+                input.hidden_states,
+                &attn_proj,
+                num_tokens * hidden,
+            )?;
 
-            // 8-10. Post-attention MLP (T>1 prefill only, separate kernels)
-            let (normed2, residual) = Self::fused_residual_rmsnorm_f16(
-                &self.stream, &self.loader, residual_ref, &attn_proj, post_norm_w,
-                cfg.rms_norm_eps, num_tokens, hidden)?;
-            // Gate+up: fused GEMM + interleaved silu_mul for N<=64, separate GEMMs for N>64
-            let use_fused_gateup = weights.fused_gate_up.is_some() && num_tokens <= 64;
-            let fused_act = if use_fused_gateup {
-                let fused_gate_up = weights.fused_gate_up.unwrap();
-                let gate_up_dim = intermediate * 2;
-                let gu_interleaved = Self::hgemm_dispatch(&self.stream, blas, lt, &normed2, fused_gate_up, num_tokens, gate_up_dim, hidden, &self.loader)?;
-                // Direct silu_mul on interleaved layout: 1 kernel, no transpose/copy
-                if let Ok(ref silu_fn) = self.loader.get_func("silu_mul_interleaved", "silu_mul_interleaved_f16_kernel") {
-                    let n_elems = num_tokens * intermediate;
-                    let mut fused_out = unsafe { self.stream.alloc::<f16>(n_elems) }
-                        .map_err(|e| LLMError::GpuError(format!("silu_interleaved alloc: {e}")))?;
-                    let total = n_elems as u32;
-                    unsafe {
-                        self.stream.launch_builder(silu_fn)
-                            .arg(&mut fused_out).arg(&gu_interleaved)
-                            .arg(&(num_tokens as i32)).arg(&(intermediate as i32))
-                            .launch(LaunchConfig { grid_dim: ((total + 255) / 256, 1, 1), block_dim: (256, 1, 1), shared_mem_bytes: 0 })
-                            .map_err(|e| LLMError::GpuError(format!("silu_interleaved: {e}")))?;
-                    }
-                    fused_out
+            // 6. Post-attention RMSNorm (f32)
+            let normed2 = Self::rms_norm(
+                &self.stream,
+                &self.loader,
+                &residual,
+                weights.post_attention_layernorm,
+                cfg.rms_norm_eps,
+                num_tokens,
+                hidden,
+            )?;
+
+            // 7. MLP / routed MoE
+            let mlp_out = if let Some(moe) = weights.gpt_oss_moe {
+                if input.is_prefill || !moe.supports_gpu_decode() {
+                    moe.forward(&self.stream, &normed2)?
                 } else {
-                    // Fallback: 2 separate GEMMs
-                    let gate = Self::hgemm_dispatch(&self.stream, blas, lt, &normed2, weights.gate_proj, num_tokens, intermediate, hidden, &self.loader)?;
-                    let up = Self::hgemm_dispatch(&self.stream, blas, lt, &normed2, weights.up_proj, num_tokens, intermediate, hidden, &self.loader)?;
-                    Self::fused_silu_mul_f16(&self.stream, &self.loader, &gate, &up, num_tokens * intermediate)?
+                    moe.forward_decode_gpu(
+                        &self.stream,
+                        &self.loader,
+                        blas,
+                        &normed2,
+                        num_tokens,
+                    )?
                 }
             } else {
-                let gate = Self::hgemm_dispatch(&self.stream, blas, lt, &normed2, weights.gate_proj, num_tokens, intermediate, hidden, &self.loader)?;
-                let up = Self::hgemm_dispatch(&self.stream, blas, lt, &normed2, weights.up_proj, num_tokens, intermediate, hidden, &self.loader)?;
-                Self::fused_silu_mul_f16(&self.stream, &self.loader, &gate, &up, num_tokens * intermediate)?
+                let gate_proj = weights.gate_proj.ok_or_else(|| {
+                    LLMError::GpuError(format!("missing dense gate_proj for layer {}", cfg.layer_idx))
+                })?;
+                let up_proj = weights.up_proj.ok_or_else(|| {
+                    LLMError::GpuError(format!("missing dense up_proj for layer {}", cfg.layer_idx))
+                })?;
+                let down_proj = weights.down_proj.ok_or_else(|| {
+                    LLMError::GpuError(format!("missing dense down_proj for layer {}", cfg.layer_idx))
+                })?;
+                let gate = CudaLinearLayer::forward_once_f16(
+                    &normed2, gate_proj, num_tokens, intermediate, hidden, blas, &self.loader,
+                )?;
+                let up = CudaLinearLayer::forward_once_f16(
+                    &normed2, up_proj, num_tokens, intermediate, hidden, blas, &self.loader,
+                )?;
+                let fused = Self::fused_silu_mul(
+                    &self.stream,
+                    &self.loader,
+                    &gate,
+                    &up,
+                    num_tokens * intermediate,
+                )?;
+                CudaLinearLayer::forward_once_f16(
+                    &fused, down_proj, num_tokens, hidden, intermediate, blas, &self.loader,
+                )?
             };
-            let mlp_out = Self::hgemm_dispatch(&self.stream, blas, lt, &fused_act, weights.down_proj, num_tokens, hidden, intermediate, &self.loader)?;
-            Ok((residual, mlp_out))
+
+            // 8. Residual
+            Self::add_tensors(&self.stream, &self.loader, &residual, &mlp_out, num_tokens * hidden)
+        }
+
+        pub fn forward(
+            &self,
+            input: &GpuLayerInput<'_>,
+            weights: &GpuLayerWeights<'_>,
+            blas: &CublasHandle,
+        ) -> Result<CudaSlice<f32>> {
+            let cfg = &self.config;
+            let num_tokens = input.num_tokens;
+            let hidden = cfg.hidden_size;
+            let num_heads = cfg.num_heads;
+            let num_kv_heads = cfg.num_kv_heads;
+            let head_dim = cfg.head_dim;
+            let intermediate = cfg.intermediate_size;
+
+            trace!(
+                layer = cfg.layer_idx,
+                num_tokens,
+                "gpu transformer layer forward"
+            );
+
+            // ---------------------------------------------------------------
+            // 1. Pre-attention RMSNorm
+            // ---------------------------------------------------------------
+            let normed = Self::rms_norm(
+                &self.stream,
+                &self.loader,
+                input.hidden_states,
+                weights.input_layernorm,
+                cfg.rms_norm_eps,
+                num_tokens,
+                hidden,
+            )?;
+
+            // All ops on this stream -- no cross-stream sync needed
+
+            // ---------------------------------------------------------------
+            // 2. QKV projections via cuBLAS sgemm
+            //    input [num_tokens, hidden] x weight^T [hidden, proj_dim]
+            // ---------------------------------------------------------------
+            let q_dim = num_heads * head_dim;
+            let kv_dim = num_kv_heads * head_dim;
+
+            let mut q = Self::linear(
+                &self.stream,
+                blas,
+                &normed,
+                weights.q_proj,
+                num_tokens,
+                q_dim,
+                hidden,
+            )?;
+            let mut k = Self::linear(
+                &self.stream,
+                blas,
+                &normed,
+                weights.k_proj,
+                num_tokens,
+                kv_dim,
+                hidden,
+            )?;
+            let mut v = Self::linear(
+                &self.stream,
+                blas,
+                &normed,
+                weights.v_proj,
+                num_tokens,
+                kv_dim,
+                hidden,
+            )?;
+
+            // Apply QKV biases if present (e.g. Qwen2.5)
+            if let Some(bias) = weights.q_proj_bias {
+                Self::add_bias(&self.stream, &self.loader, &mut q, bias, num_tokens, q_dim)?;
+            }
+            if let Some(bias) = weights.k_proj_bias {
+                Self::add_bias(&self.stream, &self.loader, &mut k, bias, num_tokens, kv_dim)?;
+            }
+            if let Some(bias) = weights.v_proj_bias {
+                Self::add_bias(&self.stream, &self.loader, &mut v, bias, num_tokens, kv_dim)?;
+            }
+
+            // ---------------------------------------------------------------
+            // 3. RoPE on Q and K
+            // ---------------------------------------------------------------
+            let (q_rot, k_rot) = Self::apply_rotary_embedding(
+                &self.stream,
+                &self.loader,
+                &q,
+                &k,
+                input.positions,
+                input.rope_cos,
+                input.rope_sin,
+                num_tokens,
+                num_heads,
+                num_kv_heads,
+                head_dim,
+            )?;
+
+            // ---------------------------------------------------------------
+            // 4. KV cache write + Attention (prefill vs decode)
+            // ---------------------------------------------------------------
+            // Always write K/V into paged cache via slot_mapping
+            info!(layer = cfg.layer_idx, "gpu_layer: cache_write start");
+            Self::cache_write(
+                &self.stream,
+                &self.loader,
+                &k_rot,
+                &v,
+                input.key_cache,
+                input.value_cache,
+                input.slot_mapping,
+                num_tokens,
+                num_kv_heads,
+                head_dim,
+            )?;
+
+            info!(layer = cfg.layer_idx, "gpu_layer: cache_write done");
+
+            let attn_out = if input.is_prefill {
+                // Prefill: use FA2 prefill kernel reading from paged cache
+                info!(layer = cfg.layer_idx, "gpu_layer: prefill_attention start");
+                Self::prefill_attention(
+                    &self.stream,
+                    &self.loader,
+                    &q_rot,
+                    input.key_cache,
+                    input.value_cache,
+                    input.block_tables,
+                    input.context_lens,
+                    input.seq_start_pos,
+                    num_tokens,
+                    input.num_seqs,
+                    num_heads,
+                    num_kv_heads,
+                    head_dim,
+                    input.max_context_len,
+                    input.block_size,
+                )?
+            } else {
+                // Decode: read from paged cache
+                info!(layer = cfg.layer_idx, "gpu_layer: decode_attention start");
+                Self::decode_attention(
+                    &self.stream,
+                    &self.loader,
+                    &q_rot,
+                    input.key_cache,
+                    input.value_cache,
+                    input.block_tables,
+                    input.context_lens,
+                    num_tokens,
+                    input.num_seqs,
+                    num_heads,
+                    num_kv_heads,
+                    head_dim,
+                    input.max_context_len,
+                    input.block_size,
+                )?
+            };
+
+            // ---------------------------------------------------------------
+            // 5. Output projection
+            // ---------------------------------------------------------------
+            let attn_proj = Self::linear(
+                &self.stream,
+                blas,
+                &attn_out,
+                weights.o_proj,
+                num_tokens,
+                hidden,
+                q_dim,
+            )?;
+
+            // ---------------------------------------------------------------
+            // Residual: hidden_states + attn_proj
+            // ---------------------------------------------------------------
+            let residual = Self::add_tensors(
+                &self.stream,
+                &self.loader,
+                input.hidden_states,
+                &attn_proj,
+                num_tokens * hidden,
+            )?;
+
+            // ---------------------------------------------------------------
+            // 6. Post-attention RMSNorm
+            // ---------------------------------------------------------------
+            let normed2 = Self::rms_norm(
+                &self.stream,
+                &self.loader,
+                &residual,
+                weights.post_attention_layernorm,
+                cfg.rms_norm_eps,
+                num_tokens,
+                hidden,
+            )?;
+
+            // ---------------------------------------------------------------
+            // 7. MLP / routed MoE
+            // ---------------------------------------------------------------
+            let mlp_out = if let Some(moe) = weights.gpt_oss_moe {
+                moe.forward(&self.stream, &normed2)?
+            } else {
+                let gate_proj = weights.gate_proj.ok_or_else(|| {
+                    LLMError::GpuError(format!("missing dense gate_proj for layer {}", cfg.layer_idx))
+                })?;
+                let up_proj = weights.up_proj.ok_or_else(|| {
+                    LLMError::GpuError(format!("missing dense up_proj for layer {}", cfg.layer_idx))
+                })?;
+                let down_proj = weights.down_proj.ok_or_else(|| {
+                    LLMError::GpuError(format!("missing dense down_proj for layer {}", cfg.layer_idx))
+                })?;
+
+                let gate = Self::linear(
+                    &self.stream,
+                    blas,
+                    &normed2,
+                    gate_proj,
+                    num_tokens,
+                    intermediate,
+                    hidden,
+                )?;
+                let up = Self::linear(
+                    &self.stream,
+                    blas,
+                    &normed2,
+                    up_proj,
+                    num_tokens,
+                    intermediate,
+                    hidden,
+                )?;
+
+                let fused = Self::fused_silu_mul(
+                    &self.stream,
+                    &self.loader,
+                    &gate,
+                    &up,
+                    num_tokens * intermediate,
+                )?;
+
+                Self::linear(
+                    &self.stream,
+                    blas,
+                    &fused,
+                    down_proj,
+                    num_tokens,
+                    hidden,
+                    intermediate,
+                )?
+            };
+
+            // ---------------------------------------------------------------
+            // 8. Residual: residual + mlp_out
+            // ---------------------------------------------------------------
+            let output = Self::add_tensors(&self.stream, &self.loader, &residual, &mlp_out, num_tokens * hidden)?;
+
+            Ok(output)
         }
 
         // ===================================================================
-        // f16 dispatch helpers
+        // Private dispatch helpers
+        //
+        // Each wraps the corresponding CUDA kernel or cuBLAS call.
+        // These are the seams where Agent 2-7 implementations plug in.
         // ===================================================================
 
-        /// RMSNorm f16: f16 input, f16 weight, f16 output.
-        fn rms_norm_f16(
+        /// RMSNorm: out[i] = (x[i] / rms) * weight[i % hidden]
+        /// where rms = sqrt(mean(x^2) + eps).
+        ///
+        /// Dispatches to the rms_norm CUDA kernel.
+        fn rms_norm(
             stream: &Arc<CudaStream>,
             loader: &KernelLoader,
-            input: &CudaSlice<f16>,
-            weight: &CudaSlice<f16>,
+            input: &CudaSlice<f32>,
+            weight: &CudaSlice<f32>,
             eps: f32,
             num_tokens: usize,
             hidden_size: usize,
-        ) -> Result<CudaSlice<f16>> {
+        ) -> Result<CudaSlice<f32>> {
             let n = num_tokens * hidden_size;
-            // Safety: kernel writes all num_tokens * hidden_size elements
-            let mut output = unsafe { stream.alloc::<f16>(n) }
-                .map_err(|e| LLMError::GpuError(format!("rms_norm_f16 alloc: {e}")))?;
+            let mut output = stream
+                .alloc_zeros::<f32>(n)
+                .map_err(|e| LLMError::GpuError(format!("rms_norm alloc failed: {e}")))?;
+
+            // Launch rms_norm kernel: one block per token, hidden_size threads per block.
+            // The kernel reads `input`, `weight`, writes `output`.
+            let module_name = "rms_norm";
+            let func_name = "rms_norm_kernel";
             let block_threads = hidden_size.min(1024) as u32;
             let cfg = LaunchConfig {
                 grid_dim: (num_tokens as u32, 1, 1),
                 block_dim: (block_threads, 1, 1),
+                // kernel uses extern __shared__ float sdata[blockDim.x]
                 shared_mem_bytes: block_threads * std::mem::size_of::<f32>() as u32,
             };
-            let kernel = loader.get_func("rms_norm_f16", "rms_norm_f16_kernel")?;
+
+            // SAFETY: All CudaSlice pointers are valid device memory allocated on
+            // the same device. Grid/block dims are checked above. The kernel reads
+            // `input` [num_tokens * hidden_size], `weight` [hidden_size], and writes
+            // `output` [num_tokens * hidden_size].
+            let kernel = loader.get_func(module_name, func_name)?;
             unsafe {
-                stream.launch_builder(&kernel)
+                stream
+                    .launch_builder(&kernel)
                     .arg(&mut output)
                     .arg(input)
                     .arg(weight)
                     .arg(&eps)
                     .arg(&(hidden_size as i32))
                     .launch(cfg)
-                    .map_err(|e| LLMError::GpuError(format!("rms_norm_f16 launch: {e}")))?;
+                    .map_err(|e| LLMError::GpuError(format!("rms_norm launch failed: {e}")))?;
             }
+
             Ok(output)
         }
 
-        /// In-place RMSNorm f16: normalizes `input` directly, no output allocation.
-        /// Safe because the kernel uses __syncthreads() between the read pass and
-        /// write pass within each block (single-token-per-block launch).
-        fn rms_norm_f16_inplace(
+        /// Linear projection via cuBLAS sgemm.
+        /// Computes output = input @ weight^T where:
+        ///   input: [m, k], weight: [n, k] (row-major), output: [m, n].
+        /// Add bias in-place: tensor[i*dim + j] += bias[j]
+        fn add_bias(
             stream: &Arc<CudaStream>,
             loader: &KernelLoader,
-            input: &mut CudaSlice<f16>,
-            weight: &CudaSlice<f16>,
-            eps: f32,
-            num_tokens: usize,
-            hidden_size: usize,
-        ) -> Result<()> {
-            let block_threads = hidden_size.min(1024) as u32;
-            let cfg = LaunchConfig {
-                grid_dim: (num_tokens as u32, 1, 1),
-                block_dim: (block_threads, 1, 1),
-                shared_mem_bytes: block_threads * std::mem::size_of::<f32>() as u32,
-            };
-            let kernel = loader.get_func("rms_norm_f16", "rms_norm_f16_kernel")?;
-            unsafe {
-                let (raw_ptr, _guard) = DevicePtrMut::device_ptr_mut(input, stream);
-                stream.launch_builder(&kernel)
-                    .arg(&raw_ptr)  // output (same ptr)
-                    .arg(&raw_ptr)  // input  (same ptr)
-                    .arg(weight)
-                    .arg(&eps)
-                    .arg(&(hidden_size as i32))
-                    .launch(cfg)
-                    .map_err(|e| LLMError::GpuError(format!("rms_norm_f16_inplace launch: {e}")))?;
-            }
-            Ok(())
-        }
-
-        /// hgemm with output allocation: f16 x f16 -> f16.
-        fn hgemm_alloc(
-            stream: &Arc<CudaStream>,
-            blas: &CublasHandle,
-            input: &CudaSlice<f16>,
-            weight: &CudaSlice<f16>,
-            m: usize,
-            n: usize,
-            k: usize,
-        ) -> Result<CudaSlice<f16>> {
-            // Safety: hgemm with beta=0 writes all m*n elements
-            let mut output = unsafe { stream.alloc::<f16>(m * n) }
-                .map_err(|e| LLMError::GpuError(format!("hgemm_alloc: {e}")))?;
-            blas.hgemm(m, n, k, f16::ONE, input, weight, f16::ZERO, &mut output)?;
-            Ok(output)
-        }
-
-        /// hgemm dispatch: uses cublasLt for M<=32 (split-K), falls back to standard cuBLAS.
-        /// GEMM dispatch: custom GEMV for M=1, cublasLt for M<=32, cuBLAS for larger.
-        fn hgemm_dispatch(
-            stream: &Arc<CudaStream>,
-            blas: &CublasHandle,
-            lt: Option<&crate::CublasLtRef>,
-            input: &CudaSlice<f16>,
-            weight: &CudaSlice<f16>,
-            m: usize,
-            n: usize,
-            k: usize,
-            loader: &KernelLoader,
-        ) -> Result<CudaSlice<f16>> {
-            let mut output = unsafe { stream.alloc::<f16>(m * n) }
-                .map_err(|e| LLMError::GpuError(format!("hgemm_dispatch: {e}")))?;
-
-            // M=1: custom GEMV kernel (vectorized half2, warp shuffle reduction)
-            if m == 1 {
-                if let Ok(kernel) = loader.get_func("gemv_f16", "gemv_f16_kernel") {
-                    let cfg = LaunchConfig {
-                        grid_dim: (n as u32, 1, 1),
-                        block_dim: (256, 1, 1),
-                        shared_mem_bytes: 0,
-                    };
-                    unsafe {
-                        stream.launch_builder(&kernel)
-                            .arg(&mut output)
-                            .arg(weight)
-                            .arg(input)
-                            .arg(&(n as i32))
-                            .arg(&(k as i32))
-                            .launch(cfg)
-                            .map_err(|e| LLMError::GpuError(format!("gemv_f16 launch: {e}")))?;
-                    }
-                    return Ok(output);
-                }
-                // Fallthrough to cuBLAS if kernel not loaded
-            }
-
-            #[cfg(feature = "cublaslt")]
-            if let Some(lt_ops) = lt {
-                if m <= rvllm_gpu::cublaslt_ops::CUBLASLT_M_THRESHOLD {
-                    lt_ops.hgemm_a_bt(m, n, k, 1.0, input, weight, 0.0, &mut output)?;
-                    return Ok(output);
-                }
-            }
-            blas.hgemm(m, n, k, f16::ONE, input, weight, f16::ZERO, &mut output)?;
-            Ok(output)
-        }
-
-        /// Add bias f16 in-place on a CudaViewMut<f16>.
-        fn add_bias_f16_view(
-            stream: &Arc<CudaStream>,
-            loader: &KernelLoader,
-            tensor: &mut CudaViewMut<'_, f16>,
-            bias: &CudaSlice<f16>,
+            tensor: &mut CudaSlice<f32>,
+            bias: &CudaSlice<f32>,
             num_tokens: usize,
             dim: usize,
         ) -> Result<()> {
-            let kernel = loader.get_func("add_bias_f16", "add_bias_f16_kernel")?;
+            let kernel = loader.get_func("add_bias", "add_bias_kernel")?;
             let cfg = LaunchConfig {
                 grid_dim: (num_tokens as u32, 1, 1),
                 block_dim: (dim.min(1024) as u32, 1, 1),
                 shared_mem_bytes: 0,
             };
+            let dim_i32 = dim as i32;
             unsafe {
-                stream.launch_builder(&kernel)
+                stream
+                    .launch_builder(&kernel)
                     .arg(tensor)
                     .arg(bias)
-                    .arg(&(dim as i32))
+                    .arg(&dim_i32)
                     .launch(cfg)
-                    .map_err(|e| LLMError::GpuError(format!("add_bias_f16 launch: {e}")))?;
+                    .map_err(|e| LLMError::GpuError(format!("add_bias launch: {e}")))?;
             }
             Ok(())
         }
 
-        /// RoPE f16 in-place on CudaViewMut<f16> Q/K slices.
-        fn apply_rotary_embedding_f16_views(
+        fn linear(
+            stream: &Arc<CudaStream>,
+            blas: &CublasHandle,
+            input: &CudaSlice<f32>,
+            weight: &CudaSlice<f32>,
+            m: usize,
+            n: usize,
+            k: usize,
+        ) -> Result<CudaSlice<f32>> {
+            let mut output = stream
+                .alloc_zeros::<f32>(m * n)
+                .map_err(|e| LLMError::GpuError(format!("linear alloc failed: {e}")))?;
+
+            blas.sgemm(m, n, k, 1.0, input, weight, 0.0, &mut output)?;
+
+            Ok(output)
+        }
+
+        /// Apply rotary positional embeddings to Q and K tensors.
+        ///
+        /// Dispatches to the rotary_embedding CUDA kernel.
+        /// Q shape: [num_tokens, num_heads * head_dim]
+        /// K shape: [num_tokens, num_kv_heads * head_dim]
+        /// positions: [num_tokens]
+        /// Apply RoPE to Q and K in a single kernel launch.
+        /// Kernel signature: (query, key, cos_cache, sin_cache, positions,
+        ///                     num_tokens, num_heads, num_kv_heads, head_dim)
+        fn apply_rotary_embedding(
             stream: &Arc<CudaStream>,
             loader: &KernelLoader,
-            q: &mut CudaViewMut<'_, f16>,
-            k: &mut CudaViewMut<'_, f16>,
-            positions: &CudaView<'_, i32>,
+            q: &CudaSlice<f32>,
+            k: &CudaSlice<f32>,
+            positions: &CudaSlice<i32>,
             rope_cos: &CudaSlice<f32>,
             rope_sin: &CudaSlice<f32>,
             num_tokens: usize,
             num_heads: usize,
             num_kv_heads: usize,
             head_dim: usize,
-        ) -> Result<()> {
-            if num_tokens == 0 { return Ok(()); }
-            let kernel = loader.get_func("rotary_embedding_f16", "rotary_embedding_f16_kernel")?;
+        ) -> Result<(CudaSlice<f32>, CudaSlice<f32>)> {
+            let q_len = num_tokens * num_heads * head_dim;
+            let k_len = num_tokens * num_kv_heads * head_dim;
+
+            // Clone Q and K so we can apply rotation in-place.
+            let mut q_out = stream
+                .alloc_zeros::<f32>(q_len)
+                .map_err(|e| LLMError::GpuError(format!("rope q alloc: {e}")))?;
+            let mut k_out = stream
+                .alloc_zeros::<f32>(k_len)
+                .map_err(|e| LLMError::GpuError(format!("rope k alloc: {e}")))?;
+
+            stream
+                .memcpy_dtod(q, &mut q_out)
+                .map_err(|e| LLMError::GpuError(format!("rope q copy: {e}")))?;
+            stream
+                .memcpy_dtod(k, &mut k_out)
+                .map_err(|e| LLMError::GpuError(format!("rope k copy: {e}")))?;
+
+            let kernel = loader.get_func("rotary_embedding", "rotary_embedding_kernel")?;
+
+            // Single launch: grid (num_tokens, max(num_heads, num_kv_heads), 1)
+            // The kernel internally guards `if (head_idx < num_kv_heads)` for K.
             let half_dim = head_dim / 2;
             let grid_y = num_heads.max(num_kv_heads) as u32;
             let cfg = LaunchConfig {
@@ -732,65 +1232,209 @@ mod inner {
                 block_dim: (half_dim.min(1024) as u32, 1, 1),
                 shared_mem_bytes: 0,
             };
+
+            let num_tokens_i32 = num_tokens as i32;
+            let num_heads_i32 = num_heads as i32;
+            let num_kv_heads_i32 = num_kv_heads as i32;
+            let head_dim_i32 = head_dim as i32;
+
+            // positions is u32 on GPU but kernel expects int* (i32).
+            // They're the same size; cast is safe.
             unsafe {
-                stream.launch_builder(&kernel)
-                    .arg(q).arg(k)
-                    .arg(rope_cos).arg(rope_sin).arg(positions)
-                    .arg(&(num_tokens as i32)).arg(&(num_heads as i32))
-                    .arg(&(num_kv_heads as i32)).arg(&(head_dim as i32))
+                stream
+                    .launch_builder(&kernel)
+                    .arg(&mut q_out)
+                    .arg(&mut k_out)
+                    .arg(rope_cos)
+                    .arg(rope_sin)
+                    .arg(positions)
+                    .arg(&num_tokens_i32)
+                    .arg(&num_heads_i32)
+                    .arg(&num_kv_heads_i32)
+                    .arg(&head_dim_i32)
                     .launch(cfg)
-                    .map_err(|e| LLMError::GpuError(format!("rope_f16 launch: {e}")))?;
+                    .map_err(|e| LLMError::GpuError(format!("rope k launch failed: {e}")))?;
             }
-            Ok(())
+
+            Ok((q_out, k_out))
         }
 
-        /// Cache write f16: f16 K/V input -> f16 paged cache (pure copy).
-        fn cache_write_f16_views(
+        /// Paged attention forward pass.
+        ///
+        /// Writes new K,V into the f16 cache at slot_mapping positions.
+        /// Input k/v are f32 (from projection); the kernel converts to f16 on write.
+        /// Uses reshape_and_cache_f16_kernel: 1 launch per layer.
+        #[allow(clippy::too_many_arguments)]
+        fn cache_write(
             stream: &Arc<CudaStream>,
             loader: &KernelLoader,
-            k: &CudaView<'_, f16>,
-            v: &CudaView<'_, f16>,
+            k: &CudaSlice<f32>,
+            v: &CudaSlice<f32>,
             key_cache: &CudaSlice<f16>,
             value_cache: &CudaSlice<f16>,
-            slot_mapping: &CudaView<'_, i32>,
+            slot_mapping: &CudaSlice<i32>,
             num_tokens: usize,
             num_kv_heads: usize,
             head_dim: usize,
         ) -> Result<()> {
+            let kernel = loader.get_func("reshape_and_cache", "reshape_and_cache_f16_kernel")?;
+
             let kv_dim = num_kv_heads * head_dim;
-            let kernel = loader.get_func("reshape_and_cache_f16", "reshape_and_cache_f16io_kernel")?;
-            let threads = kv_dim.min(1024) as u32;
             let cfg = LaunchConfig {
                 grid_dim: (num_tokens as u32, 1, 1),
-                block_dim: (threads, 1, 1),
+                block_dim: (kv_dim.min(1024) as u32, 1, 1),
                 shared_mem_bytes: 0,
             };
+
+            let num_tokens_i32 = num_tokens as i32;
+            let num_kv_heads_i32 = num_kv_heads as i32;
+            let head_dim_i32 = head_dim as i32;
+
+            // Kernel: (f16* key_cache, f16* value_cache, f32* key, f32* value, int* slot_mapping, int, int, int)
             unsafe {
-                stream.launch_builder(&kernel)
-                    .arg(key_cache).arg(value_cache)
-                    .arg(k).arg(v)
+                stream
+                    .launch_builder(&kernel)
+                    .arg(key_cache)
+                    .arg(value_cache)
+                    .arg(k)
+                    .arg(v)
                     .arg(slot_mapping)
-                    .arg(&(num_tokens as i32))
-                    .arg(&(num_kv_heads as i32))
-                    .arg(&(head_dim as i32))
+                    .arg(&num_tokens_i32)
+                    .arg(&num_kv_heads_i32)
+                    .arg(&head_dim_i32)
                     .launch(cfg)
-                    .map_err(|e| LLMError::GpuError(format!("cache_write_f16 launch: {e}")))?;
+                    .map_err(|e| LLMError::GpuError(format!("reshape_and_cache_f16 launch: {e}")))?;
             }
             Ok(())
         }
 
-        /// FA2 prefill attention: f32 Q, f16 KV cache, f32 output.
-        /// The only f32 touch point in the forward pass (prefill is one-shot).
-        #[allow(clippy::too_many_arguments)]
+        /// Prefill attention: write K/V to cache, then launch flash_attention_2_kernel
+        /// reading from the paged cache with real block_tables.
+        /// Naive prefill attention: per-head Q@K^T -> softmax -> @V via cuBLAS.
+        /// Bypasses FA2 kernel for correctness. Used only during prefill (once per request).
+        #[allow(dead_code)]
+        fn naive_prefill_attention(
+            stream: &Arc<CudaStream>,
+            blas: &CublasHandle,
+            q: &CudaSlice<f32>, // [num_tokens, num_heads * head_dim]
+            k: &CudaSlice<f32>, // [num_tokens, num_kv_heads * head_dim]
+            v: &CudaSlice<f32>, // [num_tokens, num_kv_heads * head_dim]
+            num_tokens: usize,
+            num_heads: usize,
+            num_kv_heads: usize,
+            head_dim: usize,
+        ) -> Result<CudaSlice<f32>> {
+            let scale = 1.0f32 / (head_dim as f32).sqrt();
+            let heads_per_kv = num_heads / num_kv_heads;
+            let q_stride = num_heads * head_dim;
+
+            // Output: [num_tokens, num_heads * head_dim]
+            let mut output = stream
+                .alloc_zeros::<f32>(num_tokens * q_stride)
+                .map_err(|e| LLMError::GpuError(format!("naive attn output alloc: {e}")))?;
+
+            // Per-head attention via cuBLAS
+            for h in 0..num_heads {
+                let kv_h = h / heads_per_kv;
+
+                // Extract Q_head [num_tokens, head_dim] from Q [num_tokens, num_heads * head_dim]
+                // Extract K_head [num_tokens, head_dim] from K [num_tokens, num_kv_heads * head_dim]
+                // Extract V_head [num_tokens, head_dim] from V [num_tokens, num_kv_heads * head_dim]
+                // Use CPU gather for correctness (not perf-critical for prefill)
+                let q_all: Vec<f32> = stream
+                    .clone_dtoh(q)
+                    .map_err(|e| LLMError::GpuError(format!("naive attn q DtoH: {e}")))?;
+                let k_all: Vec<f32> = stream
+                    .clone_dtoh(k)
+                    .map_err(|e| LLMError::GpuError(format!("naive attn k DtoH: {e}")))?;
+                let v_all: Vec<f32> = stream
+                    .clone_dtoh(v)
+                    .map_err(|e| LLMError::GpuError(format!("naive attn v DtoH: {e}")))?;
+
+                let kv_stride = num_kv_heads * head_dim;
+                let mut qh = vec![0.0f32; num_tokens * head_dim];
+                let mut kh = vec![0.0f32; num_tokens * head_dim];
+                let mut vh = vec![0.0f32; num_tokens * head_dim];
+
+                for t in 0..num_tokens {
+                    for d in 0..head_dim {
+                        qh[t * head_dim + d] = q_all[t * q_stride + h * head_dim + d];
+                        kh[t * head_dim + d] = k_all[t * kv_stride + kv_h * head_dim + d];
+                        vh[t * head_dim + d] = v_all[t * kv_stride + kv_h * head_dim + d];
+                    }
+                }
+
+                // scores[i][j] = sum_d qh[i][d] * kh[j][d] * scale (with causal mask)
+                let mut scores = vec![0.0f32; num_tokens * num_tokens];
+                for qi in 0..num_tokens {
+                    for ki in 0..num_tokens {
+                        if ki > qi {
+                            scores[qi * num_tokens + ki] = f32::NEG_INFINITY;
+                        } else {
+                            let mut dot = 0.0f32;
+                            for d in 0..head_dim {
+                                dot += qh[qi * head_dim + d] * kh[ki * head_dim + d];
+                            }
+                            scores[qi * num_tokens + ki] = dot * scale;
+                        }
+                    }
+                }
+
+                // Softmax per row
+                for qi in 0..num_tokens {
+                    let row = &mut scores[qi * num_tokens..(qi + 1) * num_tokens];
+                    let max = row.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+                    let mut sum = 0.0f32;
+                    for v in row.iter_mut() {
+                        *v = (*v - max).exp();
+                        sum += *v;
+                    }
+                    let inv = if sum > 0.0 { 1.0 / sum } else { 0.0 };
+                    for v in row.iter_mut() {
+                        *v *= inv;
+                    }
+                }
+
+                // out_head = scores @ vh
+                let mut out_head = vec![0.0f32; num_tokens * head_dim];
+                for qi in 0..num_tokens {
+                    for d in 0..head_dim {
+                        let mut acc = 0.0f32;
+                        for ki in 0..num_tokens {
+                            acc += scores[qi * num_tokens + ki] * vh[ki * head_dim + d];
+                        }
+                        out_head[qi * head_dim + d] = acc;
+                    }
+                }
+
+                // Scatter back into output
+                let mut out_all: Vec<f32> = stream
+                    .clone_dtoh(&output)
+                    .map_err(|e| LLMError::GpuError(format!("naive attn out DtoH: {e}")))?;
+                for t in 0..num_tokens {
+                    for d in 0..head_dim {
+                        out_all[t * q_stride + h * head_dim + d] = out_head[t * head_dim + d];
+                    }
+                }
+                output = stream
+                    .clone_htod(&out_all)
+                    .map_err(|e| LLMError::GpuError(format!("naive attn out HtoD: {e}")))?;
+            }
+
+            Ok(output)
+        }
+
+        /// FA2 prefill attention reading from f16 paged cache with real block_tables.
+        /// Q is f32, cache is f16; the kernel loads f16 and promotes to f32 internally.
         fn prefill_attention(
             stream: &Arc<CudaStream>,
             loader: &KernelLoader,
-            q: &CudaView<'_, f32>,
+            q: &CudaSlice<f32>,
             key_cache: &CudaSlice<f16>,
             value_cache: &CudaSlice<f16>,
-            block_tables: &CudaView<'_, i32>,
-            context_lens: &CudaView<'_, i32>,
-            seq_start_pos: &CudaView<'_, i32>,
+            block_tables: &CudaSlice<i32>,
+            context_lens: &CudaSlice<i32>,
+            seq_start_pos: &CudaSlice<i32>,
             num_tokens: usize,
             num_seqs: usize,
             num_heads: usize,
@@ -813,8 +1457,24 @@ mod inner {
 
             let kernel = loader.get_func("flash_attention", "flash_attention_2_f16kv_kernel")?;
 
+            let bt_len = DeviceSlice::len(block_tables);
+            info!(
+                num_tokens,
+                num_seqs,
+                num_heads,
+                num_kv_heads,
+                head_dim,
+                block_size,
+                max_context_len,
+                bt_len,
+                shared_mem_bytes,
+                "prefill_attention: dimensions"
+            );
+
             if num_seqs == 0 {
-                return Err(LLMError::GpuError("prefill_attention: num_seqs == 0".into()));
+                return Err(LLMError::GpuError(
+                    "prefill_attention: num_seqs == 0".into(),
+                ));
             }
 
             let cfg = LaunchConfig {
@@ -823,8 +1483,17 @@ mod inner {
                 shared_mem_bytes,
             };
 
-            let max_blocks_per_seq = (DeviceSlice::len(block_tables) / num_seqs) as i32;
+            // seq_start_pos is pre-computed by the caller (gpu_runner.rs) from actual
+            // query token positions, not context_lens. This correctly handles mixed
+            // prefill+decode batches where context_lens != query token counts.
 
+            let max_blocks_per_seq = if num_seqs > 0 {
+                (DeviceSlice::len(block_tables) / num_seqs) as i32
+            } else {
+                1
+            };
+
+            // Opt into extended shared memory if needed (A100 supports up to 100KB)
             if shared_mem_bytes > 49152 {
                 kernel.set_attribute(
                     cudarc::driver::sys::CUfunction_attribute_enum::CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
@@ -832,6 +1501,13 @@ mod inner {
                 ).map_err(|e| LLMError::GpuError(format!("prefill FA2 set max shared mem: {e}")))?;
             }
 
+            let p_num_heads = num_heads as i32;
+            let p_num_kv = num_kv_heads as i32;
+            let p_head_dim = head_dim as i32;
+            let p_block_size = block_size as i32;
+            let p_max_ctx = max_context_len as i32;
+            let p_num_tokens = num_tokens as i32;
+            let p_causal = 1i32;
             unsafe {
                 stream
                     .launch_builder(&kernel)
@@ -843,14 +1519,14 @@ mod inner {
                     .arg(context_lens)
                     .arg(seq_start_pos)
                     .arg(&scale)
-                    .arg(&(num_heads as i32))
-                    .arg(&(num_kv_heads as i32))
-                    .arg(&(head_dim as i32))
-                    .arg(&(block_size as i32))
-                    .arg(&(max_context_len as i32))
+                    .arg(&p_num_heads)
+                    .arg(&p_num_kv)
+                    .arg(&p_head_dim)
+                    .arg(&p_block_size)
+                    .arg(&p_max_ctx)
                     .arg(&max_blocks_per_seq)
-                    .arg(&(num_tokens as i32))
-                    .arg(&1i32) // causal
+                    .arg(&p_num_tokens)
+                    .arg(&p_causal)
                     .launch(cfg)
                     .map_err(|e| LLMError::GpuError(format!("prefill FA2 launch: {e}")))?;
             }
@@ -858,16 +1534,16 @@ mod inner {
             Ok(output)
         }
 
-        /// FA2 decode attention with f16 I/O: f16 Q, f16 KV cache, f16 output.
-        #[allow(clippy::too_many_arguments)]
-        fn decode_attention_f16io(
+        /// Decode attention: read f16 K/V from paged cache, one FA2 decode kernel per layer.
+        /// Q is f32, cache is f16; kernel promotes f16 to f32 on load.
+        fn decode_attention(
             stream: &Arc<CudaStream>,
             loader: &KernelLoader,
-            q: &CudaView<'_, f16>,
+            q: &CudaSlice<f32>,
             key_cache: &CudaSlice<f16>,
             value_cache: &CudaSlice<f16>,
-            block_tables: &CudaView<'_, i32>,
-            context_lens: &CudaView<'_, i32>,
+            block_tables: &CudaSlice<i32>,
+            context_lens: &CudaSlice<i32>,
             num_tokens: usize,
             num_seqs: usize,
             num_heads: usize,
@@ -875,62 +1551,24 @@ mod inner {
             head_dim: usize,
             max_context_len: u32,
             block_size: usize,
-        ) -> Result<CudaSlice<f16>> {
+        ) -> Result<CudaSlice<f32>> {
             let out_len = num_tokens * num_heads * head_dim;
-            let mut output = unsafe { stream.alloc::<f16>(out_len) }
-                .map_err(|e| LLMError::GpuError(format!("decode_attn_f16io alloc: {e}")))?;
+            let mut output = stream
+                .alloc_zeros::<f32>(out_len)
+                .map_err(|e| LLMError::GpuError(format!("paged_attn alloc failed: {e}")))?;
 
             let scale = 1.0f32 / (head_dim as f32).sqrt();
-            let p_num_heads = num_heads as i32;
-            let p_num_kv_heads = num_kv_heads as i32;
-            let p_head_dim = head_dim as i32;
-            let p_block_size = block_size as i32;
-            let p_max_blocks = (block_tables.len() / num_seqs.max(1)) as i32;
 
-            // FA3 kernel: 256 threads, vectorized half2 loads, warp-parallel reductions.
-            // Shared memory: 33KB (fits in default 48KB, no set_attribute needed).
-            if let Ok(fa3_kernel) = loader.get_func("flash_attention_3", "flash_attention_3_decode_f16io_kernel") {
-                const FA3_BC: usize = 64;
-                const FA3_THREADS: u32 = 256;
-                // Single KV buffer (reused for K then V) + scores + warp_reduce
-                let smem = (FA3_BC * head_dim + FA3_BC + 8) * std::mem::size_of::<f32>();
-                let shared_mem_bytes = smem as u32;
-
-                let cfg = LaunchConfig {
-                    grid_dim: (num_seqs as u32, num_heads as u32, 1),
-                    block_dim: (FA3_THREADS, 1, 1),
-                    shared_mem_bytes,
-                };
-
-                if shared_mem_bytes > 49152 {
-                    fa3_kernel.set_attribute(
-                        cudarc::driver::sys::CUfunction_attribute_enum::CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
-                        shared_mem_bytes as i32,
-                    ).map_err(|e| LLMError::GpuError(format!("FA3 set max shared mem: {e}")))?;
-                }
-
-                unsafe {
-                    stream.launch_builder(&fa3_kernel)
-                        .arg(&mut output)
-                        .arg(q)
-                        .arg(key_cache).arg(value_cache)
-                        .arg(block_tables).arg(context_lens)
-                        .arg(&scale)
-                        .arg(&p_num_heads).arg(&p_num_kv_heads)
-                        .arg(&p_head_dim).arg(&p_block_size)
-                        .arg(&p_max_blocks)
-                        .launch(cfg)
-                        .map_err(|e| LLMError::GpuError(format!("FA3 decode launch: {e}")))?;
-                }
-                return Ok(output);
-            }
-            // Fallback: FA2 kernel
+            // Use FA2 decode kernel: correct block-level reductions, GQA support.
+            // FA2_BC=64, FA2_THREADS=128 (compile-time constants in flash_attention.cu)
             const FA2_BC: usize = 64;
             const FA2_THREADS: u32 = 128;
+            // smem: s_key[FA2_BC*head_dim] + s_val[FA2_BC*head_dim] + s_score[FA2_BC] + s_reduce[FA2_THREADS/32]
             let shared_mem_bytes = ((2 * FA2_BC * head_dim + FA2_BC + (FA2_THREADS as usize / 32))
                 * std::mem::size_of::<f32>()) as u32;
 
-            let kernel = loader.get_func("flash_attention", "flash_attention_2_decode_f16io_kernel")?;
+            let module_name = "flash_attention";
+            let func_name = "flash_attention_2_decode_f16kv_kernel";
 
             let cfg = LaunchConfig {
                 grid_dim: (num_seqs as u32, num_heads as u32, 1),
@@ -938,170 +1576,70 @@ mod inner {
                 shared_mem_bytes,
             };
 
+            let kernel = loader.get_func(module_name, func_name)?;
+
+            // Opt into extended shared memory if needed
             if shared_mem_bytes > 49152 {
                 kernel.set_attribute(
                     cudarc::driver::sys::CUfunction_attribute_enum::CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
                     shared_mem_bytes as i32,
-                ).map_err(|e| LLMError::GpuError(format!("FA2 set max shared mem: {e}")))?;
+                ).map_err(|e| LLMError::GpuError(format!("decode FA2 set max shared mem: {e}")))?;
             }
 
+            let p_num_heads = num_heads as i32;
+            let p_num_kv_heads = num_kv_heads as i32;
+            let p_head_dim = head_dim as i32;
+            let p_block_size = block_size as i32;
+            let p_max_blocks = (block_tables.len() / num_seqs.max(1)) as i32;
+            // SAFETY: All slices are valid GPU memory on this device.
+            // output: [num_seqs, num_heads, head_dim]
+            // q:      [num_seqs, num_heads, head_dim]  (decode: num_seqs == num_tokens)
+            // key_cache, value_cache: [num_blocks, block_size, num_kv_heads, head_dim]
+            // block_tables: [num_seqs, max_blocks_per_seq]
+            // context_lens: [num_seqs]
+            // Scalar int args cast from usize; all values fit in i32 range.
+            // Keep this launch order in lockstep with flash_attention_2_decode_f16kv_kernel.
             unsafe {
-                stream.launch_builder(&kernel)
+                stream
+                    .launch_builder(&kernel)
                     .arg(&mut output)
                     .arg(q)
-                    .arg(key_cache).arg(value_cache)
-                    .arg(block_tables).arg(context_lens)
+                    .arg(key_cache)
+                    .arg(value_cache)
+                    .arg(block_tables)
+                    .arg(context_lens)
                     .arg(&scale)
-                    .arg(&p_num_heads).arg(&p_num_kv_heads)
-                    .arg(&p_head_dim).arg(&p_block_size)
+                    .arg(&p_num_heads)
+                    .arg(&p_num_kv_heads)
+                    .arg(&p_head_dim)
+                    .arg(&p_block_size)
                     .arg(&p_max_blocks)
                     .launch(cfg)
-                    .map_err(|e| LLMError::GpuError(format!("FA2 decode f16io launch: {e}")))?;
+                    .map_err(|e| {
+                        LLMError::GpuError(format!("flash_attention_2_decode launch failed: {e}"))
+                    })?;
             }
+
             Ok(output)
         }
 
-        /// Fused residual add + RMSNorm, all f16.
-        /// Returns (normed_output, residual) both f16.
-        pub fn fused_residual_rmsnorm_f16(
+        /// Fused SiLU activation with element-wise multiply: out = silu(gate) * up.
+        ///
+        /// Dispatches to the activation CUDA kernel.
+        fn fused_silu_mul(
             stream: &Arc<CudaStream>,
             loader: &KernelLoader,
-            input: &CudaSlice<f16>,
-            add: &CudaSlice<f16>,
-            weight: &CudaSlice<f16>,
-            eps: f32,
-            num_tokens: usize,
-            hidden_size: usize,
-        ) -> Result<(CudaSlice<f16>, CudaSlice<f16>)> {
-            let n = num_tokens * hidden_size;
-            // Safety: kernel writes all n elements to both output and residual
-            let mut output = unsafe { stream.alloc::<f16>(n) }
-                .map_err(|e| LLMError::GpuError(format!("fused_rn_f16 output alloc: {e}")))?;
-            let mut residual = unsafe { stream.alloc::<f16>(n) }
-                .map_err(|e| LLMError::GpuError(format!("fused_rn_f16 residual alloc: {e}")))?;
-            let block_threads = hidden_size.min(1024) as u32;
-            let cfg = LaunchConfig {
-                grid_dim: (num_tokens as u32, 1, 1),
-                block_dim: (block_threads, 1, 1),
-                shared_mem_bytes: block_threads * std::mem::size_of::<f32>() as u32,
-            };
-            let kernel = loader.get_func("fused_residual_rmsnorm_f16", "fused_residual_rmsnorm_f16_kernel")?;
-            unsafe {
-                stream.launch_builder(&kernel)
-                    .arg(&mut output)
-                    .arg(&mut residual)
-                    .arg(input)
-                    .arg(add)
-                    .arg(weight)
-                    .arg(&eps)
-                    .arg(&(hidden_size as i32))
-                    .launch(cfg)
-                    .map_err(|e| LLMError::GpuError(format!("fused_rn_f16 launch: {e}")))?;
-            }
-            Ok((output, residual))
-        }
-
-        /// Fused SiLU * mul, f16 variant.
-        fn fused_silu_mul_f16(
-            stream: &Arc<CudaStream>,
-            loader: &KernelLoader,
-            gate: &CudaSlice<f16>,
-            up: &CudaSlice<f16>,
+            gate: &CudaSlice<f32>,
+            up: &CudaSlice<f32>,
             n: usize,
-        ) -> Result<CudaSlice<f16>> {
-            // Safety: element-wise kernel writes all n elements
-            let mut output = unsafe { stream.alloc::<f16>(n) }
-                .map_err(|e| LLMError::GpuError(format!("fused_silu_mul_f16 alloc: {e}")))?;
-            let threads = 256u32;
-            let blocks = ((n as u32) + threads - 1) / threads;
-            let cfg = LaunchConfig {
-                grid_dim: (blocks, 1, 1),
-                block_dim: (threads, 1, 1),
-                shared_mem_bytes: 0,
-            };
-            let kernel = loader.get_func("activation_f16", "fused_silu_mul_f16_kernel")?;
-            unsafe {
-                stream.launch_builder(&kernel)
-                    .arg(&mut output)
-                    .arg(gate).arg(up)
-                    .arg(&(n as i32))
-                    .launch(cfg)
-                    .map_err(|e| LLMError::GpuError(format!("fused_silu_mul_f16 launch: {e}")))?;
-            }
-            Ok(output)
-        }
-
-        /// Fused SiLU*mul on a contiguous [gate || up] buffer, f16 variant.
-        fn fused_silu_mul_f16_split(
-            stream: &Arc<CudaStream>,
-            loader: &KernelLoader,
-            gate_up: &CudaSlice<f16>,
-            n: usize,
-        ) -> Result<CudaSlice<f16>> {
-            let gate_view = gate_up.slice(..n);
-            let up_view = gate_up.slice(n..n * 2);
-            // Safety: element-wise kernel writes all n elements
-            let mut output = unsafe { stream.alloc::<f16>(n) }
-                .map_err(|e| LLMError::GpuError(format!("fused_silu_mul_f16_split alloc: {e}")))?;
-            let threads = 256u32;
-            let blocks = ((n as u32) + threads - 1) / threads;
-            let cfg = LaunchConfig {
-                grid_dim: (blocks, 1, 1),
-                block_dim: (threads, 1, 1),
-                shared_mem_bytes: 0,
-            };
-            let kernel = loader.get_func("activation_f16", "fused_silu_mul_f16_kernel")?;
-            unsafe {
-                stream.launch_builder(&kernel)
-                    .arg(&mut output)
-                    .arg(&gate_view).arg(&up_view)
-                    .arg(&(n as i32))
-                    .launch(cfg)
-                    .map_err(|e| LLMError::GpuError(format!("fused_silu_mul_f16_split launch: {e}")))?;
-            }
-            Ok(output)
-        }
-
-        /// Element-wise tensor addition f16: out = a + b.
-        fn add_tensors_f16(
-            stream: &Arc<CudaStream>,
-            loader: &KernelLoader,
-            a: &CudaSlice<f16>,
-            b: &CudaSlice<f16>,
-            n: usize,
-        ) -> Result<CudaSlice<f16>> {
-            // Safety: element-wise kernel writes all n elements
-            let mut output = unsafe { stream.alloc::<f16>(n) }
-                .map_err(|e| LLMError::GpuError(format!("add_tensors_f16 alloc: {e}")))?;
-            let threads = 256u32;
-            let blocks = ((n as u32) + threads - 1) / threads;
-            let cfg = LaunchConfig {
-                grid_dim: (blocks, 1, 1),
-                block_dim: (threads, 1, 1),
-                shared_mem_bytes: 0,
-            };
-            let kernel = loader.get_func("add_bias_f16", "add_f16_kernel")?;
-            unsafe {
-                stream.launch_builder(&kernel)
-                    .arg(&mut output)
-                    .arg(a).arg(b)
-                    .arg(&(n as i32))
-                    .launch(cfg)
-                    .map_err(|e| LLMError::GpuError(format!("add_f16 launch: {e}")))?;
-            }
-            Ok(output)
-        }
-
-        /// Cast f16 -> f32 (used only for prefill fallback).
-        fn cast_f16_to_f32(
-            stream: &Arc<CudaStream>,
-            input: &CudaView<'_, f16>,
-            n: usize,
-            kernel: &CudaFunction,
         ) -> Result<CudaSlice<f32>> {
-            // Safety: cast kernel writes all n elements
-            let mut output = unsafe { stream.alloc::<f32>(n) }
-                .map_err(|e| LLMError::GpuError(format!("cast_f16_f32 alloc: {e}")))?;
+            let mut output = stream
+                .alloc_zeros::<f32>(n)
+                .map_err(|e| LLMError::GpuError(format!("fused_silu_mul alloc failed: {e}")))?;
+
+            let module_name = "activation";
+            let func_name = "fused_silu_mul_kernel";
+
             let threads = 256u32;
             let blocks = ((n as u32) + threads - 1) / threads;
             let cfg = LaunchConfig {
@@ -1109,27 +1647,43 @@ mod inner {
                 block_dim: (threads, 1, 1),
                 shared_mem_bytes: 0,
             };
+
+            let kernel = loader.get_func(module_name, func_name)?;
+
+            let n_i32 = n as i32;
+
+            // SAFETY: gate, up, and output all have exactly n elements.
+            // Grid covers all elements with ceil division.
             unsafe {
-                stream.launch_builder(kernel)
+                stream
+                    .launch_builder(&kernel)
                     .arg(&mut output)
-                    .arg(input)
-                    .arg(&(n as i32))
+                    .arg(gate)
+                    .arg(up)
+                    .arg(&n_i32)
                     .launch(cfg)
-                    .map_err(|e| LLMError::GpuError(format!("cast_f16_f32 launch: {e}")))?;
+                    .map_err(|e| {
+                        LLMError::GpuError(format!("fused_silu_mul launch failed: {e}"))
+                    })?;
             }
+
             Ok(output)
         }
 
-        /// Cast f32 -> f16 (used only for prefill fallback).
-        fn cast_f32_to_f16(
+        /// Fused SiLU*mul on a contiguous [gate || up] buffer.
+        fn fused_silu_mul_split(
             stream: &Arc<CudaStream>,
-            input: &CudaSlice<f32>,
+            loader: &KernelLoader,
+            gate_up: &CudaSlice<f32>,
             n: usize,
-            kernel: &CudaFunction,
-        ) -> Result<CudaSlice<f16>> {
-            // Safety: cast kernel writes all n elements
-            let mut output = unsafe { stream.alloc::<f16>(n) }
-                .map_err(|e| LLMError::GpuError(format!("cast_f32_f16 alloc: {e}")))?;
+        ) -> Result<CudaSlice<f32>> {
+            let gate = gate_up.slice(..n);
+            let up = gate_up.slice(n..n * 2);
+            let mut output = stream
+                .alloc_zeros::<f32>(n)
+                .map_err(|e| LLMError::GpuError(format!("fused_silu_mul alloc failed: {e}")))?;
+
+            let kernel = loader.get_func("activation", "fused_silu_mul_kernel")?;
             let threads = 256u32;
             let blocks = ((n as u32) + threads - 1) / threads;
             let cfg = LaunchConfig {
@@ -1137,16 +1691,124 @@ mod inner {
                 block_dim: (threads, 1, 1),
                 shared_mem_bytes: 0,
             };
+            let n_i32 = n as i32;
+
             unsafe {
-                stream.launch_builder(kernel)
+                stream
+                    .launch_builder(&kernel)
                     .arg(&mut output)
-                    .arg(input)
-                    .arg(&(n as i32))
+                    .arg(&gate)
+                    .arg(&up)
+                    .arg(&n_i32)
                     .launch(cfg)
-                    .map_err(|e| LLMError::GpuError(format!("cast_f32_f16 launch: {e}")))?;
+                    .map_err(|e| LLMError::GpuError(format!("fused_silu_mul launch failed: {e}")))?;
             }
+
             Ok(output)
         }
+
+        /// Element-wise tensor addition: out = a + b.
+        ///
+        /// Tries "add_bias" module first (Agent 20's dedicated kernel), then
+        /// "activation" module, then falls back to CPU.
+        fn add_tensors(
+            stream: &Arc<CudaStream>,
+            loader: &KernelLoader,
+            a: &CudaSlice<f32>,
+            b: &CudaSlice<f32>,
+            n: usize,
+        ) -> Result<CudaSlice<f32>> {
+            let mut output = stream
+                .alloc_zeros::<f32>(n)
+                .map_err(|e| LLMError::GpuError(format!("add_tensors alloc failed: {e}")))?;
+
+            let threads = 256u32;
+            let blocks = ((n as u32) + threads - 1) / threads;
+            let cfg = LaunchConfig {
+                grid_dim: (blocks, 1, 1),
+                block_dim: (threads, 1, 1),
+                shared_mem_bytes: 0,
+            };
+
+            let n_i32 = n as i32;
+
+            // Try dedicated add_bias module first, then activation module
+            let kernel = loader
+                .get_func("add_bias", "add_kernel")
+                .or_else(|_| loader.get_func("activation", "add_kernel"));
+
+            match kernel {
+                Ok(k) => {
+                    // SAFETY: a, b, output all have exactly n elements.
+                    unsafe {
+                        stream
+                            .launch_builder(&k)
+                            .arg(&mut output)
+                            .arg(a)
+                            .arg(b)
+                            .arg(&n_i32)
+                            .launch(cfg)
+                            .map_err(|e| {
+                                LLMError::GpuError(format!("add_kernel launch failed: {e}"))
+                            })?;
+                    }
+                }
+                Err(_) => {
+                    // Fallback: CPU add (only until kernels are compiled).
+                    let a_host = stream
+                        .clone_dtoh(a)
+                        .map_err(|e| LLMError::GpuError(format!("add dtoh a failed: {e}")))?;
+                    let b_host = stream
+                        .clone_dtoh(b)
+                        .map_err(|e| LLMError::GpuError(format!("add dtoh b failed: {e}")))?;
+                    let sum: Vec<f32> = a_host
+                        .iter()
+                        .zip(b_host.iter())
+                        .map(|(x, y)| x + y)
+                        .collect();
+                    output = stream
+                        .clone_htod(&sum)
+                        .map_err(|e| LLMError::GpuError(format!("add htod failed: {e}")))?;
+                }
+            }
+
+            Ok(output)
+        }
+    }
+
+    fn decode_mxfp_scale(scale: u8) -> f32 {
+        f32::from_bits((scale as u32) << 23)
+    }
+
+    fn apply_gpt_oss_swiglu(gate_up: &[f32], intermediate_size: usize) -> Vec<f32> {
+        let mut output = vec![0.0f32; intermediate_size];
+        for idx in 0..intermediate_size {
+            let gate = gate_up[idx * 2].min(GPT_OSS_SWIGLU_LIMIT);
+            let up = gate_up[idx * 2 + 1].clamp(-GPT_OSS_SWIGLU_LIMIT, GPT_OSS_SWIGLU_LIMIT);
+            let glu = gate * sigmoid(gate * GPT_OSS_SWIGLU_ALPHA);
+            output[idx] = (up + 1.0) * glu;
+        }
+        output
+    }
+
+    fn sigmoid(x: f32) -> f32 {
+        1.0 / (1.0 + (-x).exp())
+    }
+
+    fn top_k_indices(vals: &[f32], k: usize) -> Vec<usize> {
+        let mut indexed: Vec<(usize, f32)> = vals.iter().enumerate().map(|(i, &v)| (i, v)).collect();
+        indexed.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        indexed.into_iter().take(k).map(|(i, _)| i).collect()
+    }
+
+    fn softmax(vals: &[f32]) -> Vec<f32> {
+        if vals.is_empty() {
+            return Vec::new();
+        }
+        let max_val = vals.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+        let exps: Vec<f32> = vals.iter().map(|&v| (v - max_val).exp()).collect();
+        let sum: f32 = exps.iter().sum();
+        exps.into_iter().map(|v| v / sum).collect()
     }
 }
 
@@ -1162,5 +1824,50 @@ mod tests {
         // Under mock-gpu the `inner` module is not compiled.
         // This test confirms that the crate still builds cleanly.
         assert!(true);
+    }
+
+    #[cfg(feature = "cuda")]
+    #[test]
+    fn gpt_oss_moe_forward_mxfp4_smoke() {
+        let mut gate_up_blocks = vec![0u8; 2 * 16];
+        gate_up_blocks[0] = 0x02;
+        let gate_up_scales = vec![127u8; 2];
+        let gate_up_bias = vec![0.0f32; 2];
+
+        let mut down_blocks = vec![0u8; 32 * 16];
+        down_blocks[0] = 0x02;
+        let down_scales = vec![127u8; 32];
+        let down_bias = vec![0.0f32; 32];
+
+        let moe = super::inner::GptOssMoeLayerWeights {
+            router_weight: vec![0.0; 32],
+            router_bias: vec![0.0],
+            gate_up_blocks,
+            gate_up_scales,
+            gate_up_bias,
+            down_blocks,
+            down_scales,
+            down_bias,
+            hidden_size: 32,
+            intermediate_size: 1,
+            num_local_experts: 1,
+            num_experts_per_tok: 1,
+            router_weight_gpu: None,
+            router_bias_gpu: None,
+            gate_up_blocks_gpu: None,
+            gate_up_scales_gpu: None,
+            gate_up_bias_gpu: None,
+            down_blocks_gpu: None,
+            down_scales_gpu: None,
+            down_bias_gpu: None,
+        };
+
+        let mut input = vec![0.0f32; 32];
+        input[0] = 1.0;
+        let output = moe.forward_expert(0, &input);
+
+        let expected = 1.0 / (1.0 + (-1.702f32).exp());
+        assert!((output[0] - expected).abs() < 1e-3, "got {}", output[0]);
+        assert!(output[1..].iter().all(|v| v.abs() < 1e-6));
     }
 }

--- a/crates/rvllm-model-runner/src/gpu_runner.rs
+++ b/crates/rvllm-model-runner/src/gpu_runner.rs
@@ -17,10 +17,7 @@ pub enum ForwardOutput {
     Logits(Vec<f32>),
     /// GPU-side argmax token IDs: [num_tokens] i32 (greedy fast path).
     TokenIds(Vec<i32>),
-    /// Async DtoH in progress: token IDs are in a pinned host buffer but
-    /// the stream has not been synchronized yet. The caller must call
-    /// `sync_stream()` + read from the pinned buffer before using the data.
-    /// Fields: (actual_batch_size,) -- the pinned buffer lives on the worker.
+    /// Compatibility variant for worker async graph paths.
     TokenIdsPending { actual_batch: usize },
 }
 
@@ -29,9 +26,7 @@ mod cuda_impl {
     use std::cell::RefCell;
     use std::sync::Arc;
 
-    use std::cell::Cell;
-
-    use cudarc::driver::{CudaContext, CudaSlice, CudaStream, CudaView, DevicePtrMut, LaunchConfig, PushKernelArg};
+    use cudarc::driver::{CudaContext, CudaSlice, CudaStream, LaunchConfig, PushKernelArg};
     use half::f16;
     use tracing::{debug, info, trace};
 
@@ -39,10 +34,11 @@ mod cuda_impl {
     use crate::runner::ModelRunnerConfig;
 
     use crate::gpu_layer::{
-        GpuLayerConfig, GpuLayerInput, GpuLayerWeights, GpuTransformerLayer,
+        GptOssMoeLayerWeights, GpuLayerConfig, GpuLayerInput, GpuLayerWeights, GpuLayerWeightsF16,
+        GpuTransformerLayer,
     };
     use crate::layers::linear_cuda::CudaLinearLayer;
-
+    use crate::layers::norm_cuda::CudaRMSNorm;
     use rvllm_gpu::kernel_loader::KernelLoader;
     use rvllm_gpu::prelude::CublasHandle;
     use rvllm_kv_cache::engine_cuda::CudaCacheEngine;
@@ -92,77 +88,52 @@ mod cuda_impl {
         }
     }
 
-    /// Pre-allocated f16 scratch buffers for the forward pass.
-    /// Sized for max_batch_tokens. Reused across all layers (sequential execution).
-    pub struct F16LayerScratch {
-        pub qkv: CudaSlice<f16>,      // [max_tokens * qkv_dim]
-        pub attn_out: CudaSlice<f16>, // [max_tokens * q_dim]
-        pub o_proj: CudaSlice<f16>,   // [max_tokens * hidden]
-        pub normed: CudaSlice<f16>,   // [max_tokens * hidden]
-        pub residual: CudaSlice<f16>, // [max_tokens * hidden]
-        pub gate_up: CudaSlice<f16>,  // [max_tokens * intermediate * 2]
-        pub silu_out: CudaSlice<f16>, // [max_tokens * intermediate]
-        pub down: CudaSlice<f16>,     // [max_tokens * hidden]
-    }
-
-    /// Element offsets into the packed metadata GPU buffer.
-    #[derive(Clone, Copy, Default)]
-    struct PackedMetaOffsets {
-        token_ids: usize,
-        positions: usize,
-        context_lens: usize,
-        block_tables: usize,
-        slot_mapping: usize,
-        seq_start_pos: usize,
-        num_token_ids: usize,
-        num_positions: usize,
-        num_context_lens: usize,
-        num_block_tables: usize,
-        num_slot_mapping: usize,
-        num_seq_start_pos: usize,
-    }
-
     pub struct GpuModelRunner {
         weights: GpuModelWeights,
         cache: CudaCacheEngine,
         blas: CublasHandle,
-        #[cfg(feature = "cublaslt")]
-        blas_lt: Option<rvllm_gpu::cublaslt_ops::CublasLtOps>,
         loader: Arc<KernelLoader>,
         config: ModelRunnerConfig,
         device: Arc<CudaContext>,
         stream: Arc<CudaStream>,
         layers: Vec<GpuTransformerLayer>,
-        embed_tokens: CudaSlice<f16>,
-        final_norm_weight: CudaSlice<f16>,
-        lm_head_weight: CudaSlice<f16>,
+        embed_tokens: CudaSlice<f32>,
+        final_norm_weight: CudaSlice<f32>,
+        lm_head_weight: CudaSlice<f32>,
         rms_norm_eps: f32,
         /// Precomputed RoPE cos table on GPU: [max_position, head_dim/2]
         rope_cos: CudaSlice<f32>,
         /// Precomputed RoPE sin table on GPU: [max_position, head_dim/2]
         rope_sin: CudaSlice<f32>,
-        /// Single packed GPU buffer for all per-step metadata (token_ids,
-        /// positions, context_lens, block_tables, slot_mapping, seq_start_pos).
-        /// One memcpy_htod per decode step instead of 6 separate transfers.
-        meta_packed: RefCell<ReusableGpuBuf>,
-        /// Element offsets into meta_packed for each metadata field.
-        meta_packed_offsets: Cell<PackedMetaOffsets>,
+        /// When true, use hgemm with f16 projection weights instead of sgemm.
+        use_fp16: bool,
+        /// Pre-allocated GPU buffers for per-step metadata, reused across
+        /// forward calls to avoid CUDA malloc/free on the decode hot path.
+        /// Interior mutability via RefCell since forward_ex takes &self.
+        meta_positions: RefCell<ReusableGpuBuf>,
+        meta_context_lens: RefCell<ReusableGpuBuf>,
+        meta_block_tables: RefCell<ReusableGpuBuf>,
+        meta_slot_mapping: RefCell<ReusableGpuBuf>,
+        meta_seq_start_pos: RefCell<ReusableGpuBuf>,
+        /// Pre-allocated GPU buffer for token IDs (embedding lookup input).
+        /// Using a persistent buffer ensures the GPU pointer is stable across
+        /// forward calls, which is required for CUDA graph capture/replay.
+        meta_token_ids: RefCell<ReusableGpuBuf>,
         /// Persistent GPU output buffer for CUDA graph capture/replay.
+        /// Stores the argmax token IDs from the last forward pass. The graph
+        /// writes to this buffer's stable pointer; after replay we DtoH copy
+        /// from here to read updated results.
         graph_output: RefCell<Option<CudaSlice<i32>>>,
-        /// Reusable CPU scratch buffer for packing metadata.
+        /// Reusable CPU scratch buffer for packing metadata (avoids per-step
+        /// heap allocations for the common small-batch decode case).
         cpu_scratch: RefCell<Vec<i32>>,
         /// Fixed max blocks per sequence for CUDA graph capture/replay.
+        /// Computed as ceil(max_position / block_size) so the block_tables
+        /// stride is constant across all forward calls, preventing stale
+        /// scalar kernel args when a graph is replayed.
         graph_max_blocks: usize,
-        /// Fused QKV weights per layer: [q_dim + kv_dim + kv_dim, hidden] f16.
-        /// One GEMM instead of 3 per layer. Populated by fuse_weights().
-        fused_qkv_weights: Vec<CudaSlice<half::f16>>,
-        /// Fused gate+up weights per layer: [intermediate*2, hidden] f16.
-        /// One GEMM instead of 2 per layer. Populated by fuse_weights().
-        fused_gate_up_weights: Vec<CudaSlice<half::f16>>,
-        /// Fused QKV bias per layer (None if model has no QKV bias).
-        fused_qkv_bias: Vec<Option<CudaSlice<half::f16>>>,
-        /// Pre-allocated scratch buffers for the forward pass.
-        f16_scratch: Option<F16LayerScratch>,
+        /// Optional host-side GPT-OSS routed-expert weights, one slot per layer.
+        gpt_oss_moe_layers: Vec<Option<GptOssMoeLayerWeights>>,
     }
 
     impl GpuModelRunner {
@@ -216,16 +187,6 @@ mod cuda_impl {
                 };
                 layers.push(GpuTransformerLayer::new(layer_cfg, Arc::clone(&stream), Arc::clone(&loader)));
             }
-            info!(
-                rms_norm_eps = config.rms_norm_eps,
-                rope_theta = config.rope_theta,
-                num_heads = config.num_heads,
-                num_kv_heads = config.num_kv_heads,
-                head_dim = config.head_dim,
-                hidden = config.hidden_size,
-                vocab = config.vocab_size,
-                "model config verified"
-            );
 
             // Precompute RoPE cos/sin tables
             let head_dim = config.head_dim;
@@ -253,18 +214,15 @@ mod cuda_impl {
             let block_size = cache.block_size();
             let graph_max_blocks = (config.max_position + block_size - 1) / block_size;
             let rms_norm_eps = config.rms_norm_eps;
+            let gpt_oss_moe_layers =
+                Self::build_gpt_oss_moe_layers(&weights, &config, &stream)?;
             info!(graph_max_blocks, block_size, max_position = config.max_position,
                   "fixed block_tables stride for CUDA graph stability");
-
-            #[cfg(feature = "cublaslt")]
-            let blas_lt = rvllm_gpu::cublaslt_ops::CublasLtOps::new(stream.clone()).ok();
 
             Ok(Self {
                 weights,
                 cache,
                 blas,
-                #[cfg(feature = "cublaslt")]
-                blas_lt,
                 loader,
                 config,
                 device,
@@ -276,131 +234,18 @@ mod cuda_impl {
                 rms_norm_eps,
                 rope_cos,
                 rope_sin,
-                meta_packed: RefCell::new(ReusableGpuBuf::new()),
-                meta_packed_offsets: Cell::new(PackedMetaOffsets::default()),
+                use_fp16: false,
+                meta_positions: RefCell::new(ReusableGpuBuf::new()),
+                meta_context_lens: RefCell::new(ReusableGpuBuf::new()),
+                meta_block_tables: RefCell::new(ReusableGpuBuf::new()),
+                meta_slot_mapping: RefCell::new(ReusableGpuBuf::new()),
+                meta_seq_start_pos: RefCell::new(ReusableGpuBuf::new()),
+                meta_token_ids: RefCell::new(ReusableGpuBuf::new()),
                 graph_output: RefCell::new(None),
                 cpu_scratch: RefCell::new(Vec::with_capacity(4096)),
                 graph_max_blocks,
-                fused_qkv_weights: Vec::new(),
-                fused_gate_up_weights: Vec::new(),
-                fused_qkv_bias: Vec::new(),
-                f16_scratch: None,
+                gpt_oss_moe_layers,
             })
-        }
-
-        /// Fuse QKV and gate+up weights for each layer.
-        /// Concatenates on GPU: q_proj || k_proj || v_proj -> fused_qkv
-        /// and gate_proj || up_proj -> fused_gate_up.
-        /// Reduces 5 GEMMs to 2 per layer (3 QKV->1, 2 gate+up->1).
-        pub fn fuse_weights(&mut self) -> Result<()> {
-            let num_layers = self.layers.len();
-            let hidden = self.config.hidden_size;
-            let q_dim = self.config.num_heads * self.config.head_dim;
-            let kv_dim = self.config.num_kv_heads * self.config.head_dim;
-            let qkv_dim = q_dim + kv_dim + kv_dim;
-            let intermediate = self.config.intermediate_size;
-            let gate_up_dim = intermediate * 2;
-
-            for i in 0..num_layers {
-                // Fuse QKV: concat [q_dim, hidden] + [kv_dim, hidden] + [kv_dim, hidden]
-                let q_w = self.weights.get(
-                    &format!("model.layers.{i}.self_attn.q_proj.weight")
-                ).ok_or_else(|| LLMError::GpuError(format!("missing q_proj layer {i}")))?;
-                let k_w = self.weights.get(
-                    &format!("model.layers.{i}.self_attn.k_proj.weight")
-                ).ok_or_else(|| LLMError::GpuError(format!("missing k_proj layer {i}")))?;
-                let v_w = self.weights.get(
-                    &format!("model.layers.{i}.self_attn.v_proj.weight")
-                ).ok_or_else(|| LLMError::GpuError(format!("missing v_proj layer {i}")))?;
-
-                let mut fused_qkv = self.stream.alloc_zeros::<half::f16>(qkv_dim * hidden)
-                    .map_err(|e| LLMError::GpuError(format!("fused_qkv alloc: {e}")))?;
-                self.stream.memcpy_dtod(q_w, &mut fused_qkv.slice_mut(..q_dim * hidden))
-                    .map_err(|e| LLMError::GpuError(format!("fused_qkv q copy: {e}")))?;
-                self.stream.memcpy_dtod(k_w, &mut fused_qkv.slice_mut(q_dim * hidden..(q_dim + kv_dim) * hidden))
-                    .map_err(|e| LLMError::GpuError(format!("fused_qkv k copy: {e}")))?;
-                self.stream.memcpy_dtod(v_w, &mut fused_qkv.slice_mut((q_dim + kv_dim) * hidden..qkv_dim * hidden))
-                    .map_err(|e| LLMError::GpuError(format!("fused_qkv v copy: {e}")))?;
-                self.fused_qkv_weights.push(fused_qkv);
-
-                // Fuse gate+up: concat [intermediate, hidden] + [intermediate, hidden]
-                let gate_w = self.weights.get(
-                    &format!("model.layers.{i}.mlp.gate_proj.weight")
-                ).ok_or_else(|| LLMError::GpuError(format!("missing gate_proj layer {i}")))?;
-                let up_w = self.weights.get(
-                    &format!("model.layers.{i}.mlp.up_proj.weight")
-                ).ok_or_else(|| LLMError::GpuError(format!("missing up_proj layer {i}")))?;
-
-                let mut fused_gu = self.stream.alloc_zeros::<half::f16>(gate_up_dim * hidden)
-                    .map_err(|e| LLMError::GpuError(format!("fused_gate_up alloc: {e}")))?;
-                self.stream.memcpy_dtod(gate_w, &mut fused_gu.slice_mut(..intermediate * hidden))
-                    .map_err(|e| LLMError::GpuError(format!("fused_gate_up gate copy: {e}")))?;
-                self.stream.memcpy_dtod(up_w, &mut fused_gu.slice_mut(intermediate * hidden..gate_up_dim * hidden))
-                    .map_err(|e| LLMError::GpuError(format!("fused_gate_up up copy: {e}")))?;
-                self.fused_gate_up_weights.push(fused_gu);
-
-                // Fuse QKV biases: concat q_bias || k_bias || v_bias (already f16)
-                let q_bias = self.weights.get(&format!("model.layers.{i}.self_attn.q_proj.bias"));
-                let k_bias = self.weights.get(&format!("model.layers.{i}.self_attn.k_proj.bias"));
-                let v_bias = self.weights.get(&format!("model.layers.{i}.self_attn.v_proj.bias"));
-                if let (Some(qb), Some(kb), Some(vb)) = (q_bias, k_bias, v_bias) {
-                    let mut fused_bias = self.stream.alloc_zeros::<half::f16>(qkv_dim)
-                        .map_err(|e| LLMError::GpuError(format!("fused_bias alloc: {e}")))?;
-                    self.stream.memcpy_dtod(qb, &mut fused_bias.slice_mut(..q_dim))
-                        .map_err(|e| LLMError::GpuError(format!("fused_bias q copy: {e}")))?;
-                    self.stream.memcpy_dtod(kb, &mut fused_bias.slice_mut(q_dim..q_dim + kv_dim))
-                        .map_err(|e| LLMError::GpuError(format!("fused_bias k copy: {e}")))?;
-                    self.stream.memcpy_dtod(vb, &mut fused_bias.slice_mut(q_dim + kv_dim..qkv_dim))
-                        .map_err(|e| LLMError::GpuError(format!("fused_bias v copy: {e}")))?;
-                    self.fused_qkv_bias.push(Some(fused_bias));
-                } else {
-                    self.fused_qkv_bias.push(None);
-                }
-            }
-
-            info!(num_layers, qkv_dim, gate_up_dim, "fused QKV and gate+up weights (f16)");
-
-            self.alloc_scratch()?;
-            Ok(())
-        }
-
-        /// Pre-allocate a reusable set of f16 scratch buffers for the forward pass.
-        /// Sized for max padded batch (256). Since all layers are processed
-        /// sequentially, one set of buffers covers every layer.
-        fn alloc_scratch(&mut self) -> Result<()> {
-            let max_tokens: usize = 512; // support up to N=512 batch decode
-            let hidden = self.config.hidden_size;
-            let q_dim = self.config.num_heads * self.config.head_dim;
-            let kv_dim = self.config.num_kv_heads * self.config.head_dim;
-            let qkv_dim = q_dim + kv_dim + kv_dim;
-            let intermediate = self.config.intermediate_size;
-
-            let alloc = |n: usize| -> Result<CudaSlice<f16>> {
-                self.stream.alloc_zeros::<f16>(n)
-                    .map_err(|e| LLMError::GpuError(format!("f16 scratch alloc ({n} elems): {e}")))
-            };
-
-            let scratch = F16LayerScratch {
-                qkv: alloc(max_tokens * qkv_dim)?,
-                attn_out: alloc(max_tokens * q_dim)?,
-                o_proj: alloc(max_tokens * hidden)?,
-                normed: alloc(max_tokens * hidden)?,
-                residual: alloc(max_tokens * hidden)?,
-                gate_up: alloc(max_tokens * intermediate * 2)?,
-                silu_out: alloc(max_tokens * intermediate)?,
-                down: alloc(max_tokens * hidden)?,
-            };
-
-            let total_bytes = (max_tokens * (qkv_dim + q_dim + hidden * 3 + intermediate * 3)) * 2;
-            info!(max_tokens, total_bytes, "f16 layer scratch allocated");
-            self.f16_scratch = Some(scratch);
-            Ok(())
-        }
-
-        /// Access the pre-allocated f16 scratch buffers.
-        /// Panics if called before fuse_weights().
-        pub fn f16_scratch(&self) -> &F16LayerScratch {
-            self.f16_scratch.as_ref().expect("f16_scratch not allocated; call fuse_weights() first")
         }
 
         pub fn forward(
@@ -412,9 +257,10 @@ mod cuda_impl {
         ) -> Result<Vec<f32>> {
             match self.forward_ex(token_ids, positions, attn_meta, is_prefill, false)? {
                 ForwardOutput::Logits(logits) => Ok(logits),
-                ForwardOutput::TokenIds(_) | ForwardOutput::TokenIdsPending { .. } => {
-                    unreachable!("greedy_only=false must return Logits")
-                }
+                ForwardOutput::TokenIds(_) => unreachable!("greedy_only=false must return Logits"),
+                ForwardOutput::TokenIdsPending { .. } => Err(LLMError::GpuError(
+                    "greedy_only=false returned pending token IDs".into(),
+                )),
             }
         }
 
@@ -441,142 +287,188 @@ mod cuda_impl {
 
             debug!(num_tokens, num_seqs, is_prefill, greedy_only, "GpuModelRunner::forward_ex");
 
+            // Upload per-step metadata into reusable GPU buffers.
+            // On the decode hot path, buffer sizes are stable so this is pure
+            // memcpy_htod with zero CUDA malloc/free. The CPU scratch vec is
+            // also reused to avoid per-step heap allocations.
+            // Use fixed stride for block_tables so the layout matches what
+            // CUDA graph kernels expect (p_max_blocks is baked as a scalar).
+            let max_blocks = self.graph_max_blocks;
             let max_context_len = attn_meta.max_context_len;
 
-            // Single packed upload: all 6 metadata fields in one memcpy_htod.
-            self.upload_metadata(token_ids, positions, attn_meta)?;
+            {
+                let mut scratch = self.cpu_scratch.borrow_mut();
 
-            // Step 1: token embedding lookup from packed buffer
-            info!("gpu_runner: embedding lookup");
+                // positions (i32)
+                scratch.clear();
+                scratch.extend(positions.iter().map(|&p| p as i32));
+                self.meta_positions.borrow_mut().upload(&scratch, &self.stream)
+                    .map_err(|e| LLMError::GpuError(format!("positions HtoD: {e}")))?;
 
-            // === f16 forward path ===
-            let debug_fwd = std::env::var("RVLLM_DEBUG").is_ok();
-            let mut hidden_f16 = self.embedding_lookup_from_meta(num_tokens)?;
+                // context_lens (i32)
+                scratch.clear();
+                scratch.extend(attn_meta.context_lens.iter().map(|&c| c as i32));
+                self.meta_context_lens.borrow_mut().upload(&scratch, &self.stream)
+                    .map_err(|e| LLMError::GpuError(format!("context_lens HtoD: {e}")))?;
 
-            if debug_fwd {
-                let vals: Vec<f16> = self.stream.clone_dtoh(&hidden_f16)
-                    .map_err(|e| LLMError::GpuError(format!("debug dtoh: {e}")))?;
-                let first10: Vec<f32> = vals.iter().take(10).map(|v| v.to_f32()).collect();
-                let has_nan = vals.iter().any(|v| v.to_f32().is_nan());
-                let has_inf = vals.iter().any(|v| v.to_f32().is_infinite());
-                let max_abs = vals.iter().map(|v| v.to_f32().abs()).fold(0.0f32, f32::max);
-                info!("DEBUG embed: first10={first10:?} nan={has_nan} inf={has_inf} max={max_abs}");
+                // block_tables flattened [num_seqs, graph_max_blocks] (i32)
+                scratch.clear();
+                scratch.resize(num_seqs * max_blocks, 0i32);
+                for (s, row) in attn_meta.block_tables.iter().enumerate() {
+                    for (b, &blk) in row.iter().enumerate() {
+                        scratch[s * max_blocks + b] = blk as i32;
+                    }
+                }
+                self.meta_block_tables.borrow_mut().upload(&scratch, &self.stream)
+                    .map_err(|e| LLMError::GpuError(format!("block_tables HtoD: {e}")))?;
+
+                // slot_mapping (i32)
+                scratch.clear();
+                scratch.extend(attn_meta.slot_mapping.iter().map(|&s| s as i32));
+                self.meta_slot_mapping.borrow_mut().upload(&scratch, &self.stream)
+                    .map_err(|e| LLMError::GpuError(format!("slot_mapping HtoD: {e}")))?;
+
+                // seq_start_pos from query_lens [num_seqs + 1] (i32)
+                scratch.clear();
+                let mut pos = 0i32;
+                for &ql in &attn_meta.query_lens {
+                    scratch.push(pos);
+                    pos += ql as i32;
+                }
+                scratch.push(num_tokens as i32);
+                self.meta_seq_start_pos.borrow_mut().upload(&scratch, &self.stream)
+                    .map_err(|e| LLMError::GpuError(format!("seq_start_pos HtoD: {e}")))?;
             }
 
+            let meta_pos = self.meta_positions.borrow();
+            let meta_cl = self.meta_context_lens.borrow();
+            let meta_bt = self.meta_block_tables.borrow();
+            let meta_sm = self.meta_slot_mapping.borrow();
+            let meta_ssp = self.meta_seq_start_pos.borrow();
+
+            // Step 1: token embedding lookup
+            info!("gpu_runner: embedding lookup");
+            let mut hidden_states = self.embedding_lookup(token_ids)?;
+
+            // Step 2: transformer layers
             let gpu_cache = self.cache.gpu_cache();
             let num_layers = self.layers.len();
-            let meta_packed = self.meta_packed.borrow();
-            let packed_buf = meta_packed.slice();
-            let offsets = self.meta_packed_offsets.get();
-            let mut prev_mlp_out: Option<CudaSlice<f16>> = None;
             for (layer_idx, layer) in self.layers.iter().enumerate() {
+                if layer_idx == 0 || layer_idx == num_layers - 1 {
+                    info!(layer = layer_idx, use_fp16 = self.use_fp16, "gpu_runner: layer start");
+                }
                 let (key_cache, value_cache) = &gpu_cache[layer_idx];
                 let input = GpuLayerInput {
-                    hidden_states: &hidden_f16,
-                    positions: packed_buf.slice(offsets.positions..offsets.positions + offsets.num_positions),
+                    hidden_states: &hidden_states,
+                    positions: meta_pos.slice(),
                     key_cache,
                     value_cache,
-                    block_tables: packed_buf.slice(offsets.block_tables..offsets.block_tables + offsets.num_block_tables),
-                    context_lens: packed_buf.slice(offsets.context_lens..offsets.context_lens + offsets.num_context_lens),
-                    slot_mapping: packed_buf.slice(offsets.slot_mapping..offsets.slot_mapping + offsets.num_slot_mapping),
+                    block_tables: meta_bt.slice(),
+                    context_lens: meta_cl.slice(),
+                    slot_mapping: meta_sm.slice(),
                     num_tokens,
                     num_seqs,
                     max_context_len,
                     block_size,
                     is_prefill,
-                    seq_start_pos: packed_buf.slice(offsets.seq_start_pos..offsets.seq_start_pos + offsets.num_seq_start_pos),
+                    seq_start_pos: meta_ssp.slice(),
                     rope_cos: &self.rope_cos,
                     rope_sin: &self.rope_sin,
                 };
-                let weights = self.layer_weights(layer_idx)?;
-                let (residual, mlp_out) = layer.forward(&input, &weights, &self.blas, prev_mlp_out.as_ref(), self.cublaslt_ref())?;
-                hidden_f16 = residual;
-                prev_mlp_out = Some(mlp_out);
-
-                if debug_fwd && (layer_idx < 3 || layer_idx == num_layers - 1) {
-                    let vals: Vec<f16> = self.stream.clone_dtoh(&hidden_f16)
-                        .map_err(|e| LLMError::GpuError(format!("debug dtoh: {e}")))?;
-                    let first5: Vec<f32> = vals.iter().take(5).map(|v| v.to_f32()).collect();
-                    let has_nan = vals.iter().any(|v| v.to_f32().is_nan());
-                    let has_inf = vals.iter().any(|v| v.to_f32().is_infinite());
-                    let max_abs = vals.iter().map(|v| v.to_f32().abs()).fold(0.0f32, f32::max);
-                    info!("DEBUG layer {layer_idx} residual: first5={first5:?} nan={has_nan} inf={has_inf} max={max_abs}");
-
-                    let mvals: Vec<f16> = self.stream.clone_dtoh(prev_mlp_out.as_ref().unwrap())
-                        .map_err(|e| LLMError::GpuError(format!("debug dtoh: {e}")))?;
-                    let mfirst5: Vec<f32> = mvals.iter().take(5).map(|v| v.to_f32()).collect();
-                    let mnan = mvals.iter().any(|v| v.to_f32().is_nan());
-                    let mmax = mvals.iter().map(|v| v.to_f32().abs()).fold(0.0f32, f32::max);
-                    info!("DEBUG layer {layer_idx} mlp_out: first5={mfirst5:?} nan={mnan} max={mmax}");
+                hidden_states = if self.use_fp16 {
+                    let weights = self.layer_weights_f16(layer_idx)?;
+                    layer.forward_f16(&input, &weights, &self.blas)?
+                } else {
+                    let weights = self.layer_weights(layer_idx)?;
+                    layer.forward(&input, &weights, &self.blas)?
+                };
+                if layer_idx == 0 || layer_idx == num_layers - 1 {
+                    info!(layer = layer_idx, "gpu_runner: layer done");
                 }
             }
 
-            // Final: fuse last layer's residual add with final RMSNorm
-            let normed_f16 = if let Some(ref last_mlp) = prev_mlp_out {
-                let (n, _) = GpuTransformerLayer::fused_residual_rmsnorm_f16(
-                    &self.stream, &self.loader,
-                    &hidden_f16, last_mlp, &self.final_norm_weight,
-                    self.rms_norm_eps, num_tokens, hidden_size,
-                )?;
-                n
-            } else {
-                self.rms_norm_f16_runner(&hidden_f16, &self.final_norm_weight, hidden_size)?
-            };
-
-            if debug_fwd {
-                // Check normed hidden and top logits
-                let nvals: Vec<f16> = self.stream.clone_dtoh(&normed_f16)
-                    .map_err(|e| LLMError::GpuError(format!("debug dtoh: {e}")))?;
-                let nfirst5: Vec<f32> = nvals.iter().take(5).map(|v| v.to_f32()).collect();
-                let nnan = nvals.iter().any(|v| v.to_f32().is_nan());
-                let nmax = nvals.iter().map(|v| v.to_f32().abs()).fold(0.0f32, f32::max);
-                info!("DEBUG normed: first5={nfirst5:?} nan={nnan} max={nmax}");
-
-                // Compute full logits and find top-5
-                let logits_dbg = CudaLinearLayer::forward_f16_in(
-                    &normed_f16, &self.lm_head_weight, num_tokens, vocab_size, hidden_size,
-                    &self.blas,
-                )?;
-                let logits_cpu: Vec<f32> = self.stream.clone_dtoh(&logits_dbg)
-                    .map_err(|e| LLMError::GpuError(format!("debug logits dtoh: {e}")))?;
-                // Find top-5 for last token
-                let last_start = (num_tokens - 1) * vocab_size;
-                let last_logits = &logits_cpu[last_start..last_start + vocab_size];
-                let mut indexed: Vec<(usize, f32)> = last_logits.iter().enumerate().map(|(i, &v)| (i, v)).collect();
-                indexed.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
-                let top5: Vec<(usize, f32)> = indexed[..5.min(indexed.len())].to_vec();
-                info!("DEBUG top5_logits: {:?}", top5);
-                info!("DEBUG logits range: min={:.2} max={:.2} mean={:.4}",
-                    last_logits.iter().cloned().fold(f32::INFINITY, f32::min),
-                    last_logits.iter().cloned().fold(f32::NEG_INFINITY, f32::max),
-                    last_logits.iter().sum::<f32>() / last_logits.len() as f32,
-                );
-            }
-
-            // LM head + argmax: f16 hidden -> fused argmax
-            if num_tokens == 1 && greedy_only {
-                let token_ids_gpu = self.gpu_fused_lm_head_argmax_f16_hidden(
-                    &normed_f16, &self.lm_head_weight, vocab_size, hidden_size)?;
-                let token_ids_cpu = self.stream.clone_dtoh(&token_ids_gpu)
-                    .map_err(|e| LLMError::GpuError(format!("fused_lm_head token DtoH: {e}")))?;
-                return Ok(ForwardOutput::TokenIds(token_ids_cpu));
-            }
-
-            // Full logits path: hgemm f16 hidden x f16 lm_head -> f32 logits
-            let logits_gpu = CudaLinearLayer::forward_f16_in(
-                &normed_f16, &self.lm_head_weight, num_tokens, vocab_size, hidden_size,
-                &self.blas,
+            // Step 3: final RMSNorm (all on stream 0, no sync needed)
+            let normed = CudaRMSNorm::forward(
+                &hidden_states,
+                &self.final_norm_weight,
+                self.rms_norm_eps,
+                hidden_size,
+                &self.loader,
+                &self.stream,
             )?;
 
-            if greedy_only {
-                let token_ids_gpu = self.gpu_argmax(&logits_gpu, num_tokens, vocab_size)?;
-                let token_ids_cpu = self.stream.clone_dtoh(&token_ids_gpu)
-                    .map_err(|e| LLMError::GpuError(format!("argmax DtoH: {e}")))?;
+            // Step 4+5: fused LM-head + argmax for single-token greedy decode
+            if num_tokens == 1 && greedy_only {
+                let token_ids_gpu = if self.use_fp16 {
+                    let lm_f16 = self
+                        .weights
+                        .get_f16("lm_head.weight")
+                        .or_else(|| self.weights.get_f16("model.embed_tokens.weight"));
+                    if let Some(lm_w) = lm_f16 {
+                        self.gpu_fused_lm_head_argmax_f16(&normed, lm_w, vocab_size, hidden_size)?
+                    } else {
+                        self.gpu_fused_lm_head_argmax(&normed, &self.lm_head_weight, vocab_size, hidden_size)?
+                    }
+                } else {
+                    self.gpu_fused_lm_head_argmax(&normed, &self.lm_head_weight, vocab_size, hidden_size)?
+                };
+                let token_ids_cpu = self
+                    .stream
+                    .clone_dtoh(&token_ids_gpu)
+                    .map_err(|e| LLMError::GpuError(format!("fused_lm_head token DtoH: {e}")))?;
+                debug!("forward_ex complete (fused lm_head+argmax, 4 bytes DtoH)");
                 return Ok(ForwardOutput::TokenIds(token_ids_cpu));
             }
 
-            let logits_cpu = self.stream.clone_dtoh(&logits_gpu)
+            // Step 4: LM head  normed [num_tokens, hidden] @ lm_head^T [hidden, vocab]
+            let logits_gpu = if self.use_fp16 {
+                let lm_f16 = self
+                    .weights
+                    .get_f16("lm_head.weight")
+                    .or_else(|| self.weights.get_f16("model.embed_tokens.weight"));
+                if let Some(lm_w) = lm_f16 {
+                    CudaLinearLayer::forward_once_f16(
+                        &normed, lm_w, num_tokens, vocab_size, hidden_size, &self.blas, &self.loader,
+                    )?
+                } else {
+                    CudaLinearLayer::forward_once(
+                        &normed, &self.lm_head_weight, None,
+                        num_tokens, vocab_size, hidden_size, &self.blas,
+                    )?
+                }
+            } else {
+                CudaLinearLayer::forward_once(
+                    &normed, &self.lm_head_weight, None,
+                    num_tokens, vocab_size, hidden_size, &self.blas,
+                )?
+            };
+
+            // Step 5: greedy fast path -- argmax on GPU, copy only token IDs
+            if greedy_only {
+                let token_ids_gpu = self.gpu_argmax(&logits_gpu, num_tokens, vocab_size)?;
+                let token_ids_cpu = self
+                    .stream
+                    .clone_dtoh(&token_ids_gpu)
+                    .map_err(|e| LLMError::GpuError(format!("argmax token_ids DtoH: {e}")))?;
+                debug!(
+                    num_tokens,
+                    "forward_ex complete (greedy, {} bytes DtoH)",
+                    num_tokens * 4
+                );
+                return Ok(ForwardOutput::TokenIds(token_ids_cpu));
+            }
+
+            // Step 5 (fallback): full logits DtoH for temperature>0 sampling
+            let logits_cpu = self
+                .stream
+                .clone_dtoh(&logits_gpu)
                 .map_err(|e| LLMError::GpuError(format!("logits DtoH: {e}")))?;
+
+            debug!(
+                logits_len = logits_cpu.len(),
+                expected = num_tokens * vocab_size,
+                "forward_ex complete (full logits)"
+            );
             Ok(ForwardOutput::Logits(logits_cpu))
         }
 
@@ -593,105 +485,72 @@ mod cuda_impl {
         ) -> Result<()> {
             let num_tokens = token_ids.len();
             let num_seqs = attn_meta.context_lens.len();
+            // Use the fixed max_blocks stride so that block_tables.len()/num_seqs
+            // is always the same value. This is critical for CUDA graph replay:
+            // the attention kernel receives p_max_blocks as a scalar arg baked
+            // into the graph, and the data layout must match that stride.
             let max_blocks = self.graph_max_blocks;
 
             let mut scratch = self.cpu_scratch.borrow_mut();
+
+            // token_ids (i32)
             scratch.clear();
-
-            // Pack all 6 metadata fields contiguously, recording offsets.
-            let token_ids_off = scratch.len();
             scratch.extend(token_ids.iter().map(|&t| t as i32));
-            let num_token_ids = scratch.len() - token_ids_off;
+            self.meta_token_ids.borrow_mut().upload(&scratch, &self.stream)
+                .map_err(|e| LLMError::GpuError(format!("token_ids HtoD: {e}")))?;
 
-            let positions_off = scratch.len();
+            // positions (i32)
+            scratch.clear();
             scratch.extend(positions.iter().map(|&p| p as i32));
-            let num_positions = scratch.len() - positions_off;
+            self.meta_positions.borrow_mut().upload(&scratch, &self.stream)
+                .map_err(|e| LLMError::GpuError(format!("positions HtoD: {e}")))?;
 
-            let context_lens_off = scratch.len();
+            // context_lens (i32)
+            scratch.clear();
             scratch.extend(attn_meta.context_lens.iter().map(|&c| c as i32));
-            let num_context_lens = scratch.len() - context_lens_off;
+            self.meta_context_lens.borrow_mut().upload(&scratch, &self.stream)
+                .map_err(|e| LLMError::GpuError(format!("context_lens HtoD: {e}")))?;
 
-            // block_tables: [num_seqs, graph_max_blocks], zero-padded.
-            let block_tables_off = scratch.len();
-            let bt_len = num_seqs * max_blocks;
-            let new_len = scratch.len() + bt_len;
-            scratch.resize(new_len, 0i32);
+            // block_tables flattened [num_seqs, graph_max_blocks] (i32)
+            // Always padded to fixed stride for CUDA graph pointer stability.
+            scratch.clear();
+            scratch.resize(num_seqs * max_blocks, 0i32);
             for (s, row) in attn_meta.block_tables.iter().enumerate() {
                 for (b, &blk) in row.iter().enumerate() {
-                    scratch[block_tables_off + s * max_blocks + b] = blk as i32;
+                    scratch[s * max_blocks + b] = blk as i32;
                 }
             }
+            self.meta_block_tables.borrow_mut().upload(&scratch, &self.stream)
+                .map_err(|e| LLMError::GpuError(format!("block_tables HtoD: {e}")))?;
 
-            let slot_mapping_off = scratch.len();
+            // slot_mapping (i32)
+            scratch.clear();
             scratch.extend(attn_meta.slot_mapping.iter().map(|&s| s as i32));
-            let num_slot_mapping = scratch.len() - slot_mapping_off;
+            self.meta_slot_mapping.borrow_mut().upload(&scratch, &self.stream)
+                .map_err(|e| LLMError::GpuError(format!("slot_mapping HtoD: {e}")))?;
 
-            let seq_start_pos_off = scratch.len();
+            // seq_start_pos from query_lens [num_seqs + 1] (i32)
+            scratch.clear();
             let mut pos = 0i32;
             for &ql in &attn_meta.query_lens {
                 scratch.push(pos);
                 pos += ql as i32;
             }
             scratch.push(num_tokens as i32);
-            let num_seq_start_pos = scratch.len() - seq_start_pos_off;
-
-            // Single packed upload (1 memcpy_htod instead of 6).
-            self.meta_packed.borrow_mut().upload(&scratch, &self.stream)
-                .map_err(|e| LLMError::GpuError(format!("packed metadata HtoD: {e}")))?;
-
-            self.meta_packed_offsets.set(PackedMetaOffsets {
-                token_ids: token_ids_off,
-                positions: positions_off,
-                context_lens: context_lens_off,
-                block_tables: block_tables_off,
-                slot_mapping: slot_mapping_off,
-                seq_start_pos: seq_start_pos_off,
-                num_token_ids,
-                num_positions,
-                num_context_lens,
-                num_block_tables: bt_len,
-                num_slot_mapping,
-                num_seq_start_pos,
-            });
+            self.meta_seq_start_pos.borrow_mut().upload(&scratch, &self.stream)
+                .map_err(|e| LLMError::GpuError(format!("seq_start_pos HtoD: {e}")))?;
 
             Ok(())
         }
 
-        /// Upload metadata padded to `padded_batch` tokens.
-        /// Extra slots are filled with dummy data (duplicating seq 0's metadata).
         pub fn upload_metadata_padded(
             &self,
             token_ids: &[u32],
             positions: &[u32],
             attn_meta: &crate::bridge::AttentionMetadata,
-            padded_batch: usize,
+            _padded_batch: usize,
         ) -> Result<()> {
-            let actual = token_ids.len();
-            if actual >= padded_batch {
-                return self.upload_metadata(token_ids, positions, attn_meta);
-            }
-            let pad_count = padded_batch - actual;
-
-            // Pad token_ids with 0 (padding token)
-            let mut padded_tokens: Vec<u32> = token_ids.to_vec();
-            padded_tokens.resize(padded_batch, 0);
-
-            // Pad positions with 0
-            let mut padded_positions: Vec<u32> = positions.to_vec();
-            padded_positions.resize(padded_batch, 0);
-
-            // Pad attention metadata
-            let mut padded_meta = attn_meta.clone();
-            let dummy_ctx = if attn_meta.context_lens.is_empty() { 1 } else { attn_meta.context_lens[0] };
-            padded_meta.context_lens.resize(padded_batch, dummy_ctx);
-            padded_meta.query_lens.resize(padded_batch, 1);
-            let dummy_bt = if attn_meta.block_tables.is_empty() { vec![] } else { attn_meta.block_tables[0].clone() };
-            for _ in 0..pad_count {
-                padded_meta.block_tables.push(dummy_bt.clone());
-            }
-            padded_meta.slot_mapping.resize(padded_batch, 0);
-
-            self.upload_metadata(&padded_tokens, &padded_positions, &padded_meta)
+            self.upload_metadata(token_ids, positions, attn_meta)
         }
 
         /// Run the forward pass using already-uploaded metadata buffers.
@@ -716,74 +575,118 @@ mod cuda_impl {
                 return Err(LLMError::ModelError("empty input".into()));
             }
 
-            let mut hidden_f16 = self.embedding_lookup_from_meta(num_tokens)?;
+            let meta_pos = self.meta_positions.borrow();
+            let meta_cl = self.meta_context_lens.borrow();
+            let meta_bt = self.meta_block_tables.borrow();
+            let meta_sm = self.meta_slot_mapping.borrow();
+            let meta_ssp = self.meta_seq_start_pos.borrow();
 
+            // Step 1: token embedding lookup from persistent buffer
+            let mut hidden_states = self.embedding_lookup_from_meta(num_tokens)?;
+
+            // Step 2: transformer layers
             let gpu_cache = self.cache.gpu_cache();
             let num_layers = self.layers.len();
-            let meta_packed = self.meta_packed.borrow();
-            let packed_buf = meta_packed.slice();
-            let offsets = self.meta_packed_offsets.get();
-            let mut prev_mlp_out: Option<CudaSlice<f16>> = None;
             for (layer_idx, layer) in self.layers.iter().enumerate() {
+                if layer_idx == 0 || layer_idx == num_layers - 1 {
+                    trace!(layer = layer_idx, use_fp16 = self.use_fp16, "gpu_runner graph body: layer");
+                }
                 let (key_cache, value_cache) = &gpu_cache[layer_idx];
                 let input = GpuLayerInput {
-                    hidden_states: &hidden_f16,
-                    positions: packed_buf.slice(offsets.positions..offsets.positions + offsets.num_positions),
+                    hidden_states: &hidden_states,
+                    positions: meta_pos.slice(),
                     key_cache,
                     value_cache,
-                    block_tables: packed_buf.slice(offsets.block_tables..offsets.block_tables + offsets.num_block_tables),
-                    context_lens: packed_buf.slice(offsets.context_lens..offsets.context_lens + offsets.num_context_lens),
-                    slot_mapping: packed_buf.slice(offsets.slot_mapping..offsets.slot_mapping + offsets.num_slot_mapping),
+                    block_tables: meta_bt.slice(),
+                    context_lens: meta_cl.slice(),
+                    slot_mapping: meta_sm.slice(),
                     num_tokens,
                     num_seqs,
                     max_context_len,
                     block_size,
                     is_prefill,
-                    seq_start_pos: packed_buf.slice(offsets.seq_start_pos..offsets.seq_start_pos + offsets.num_seq_start_pos),
+                    seq_start_pos: meta_ssp.slice(),
                     rope_cos: &self.rope_cos,
                     rope_sin: &self.rope_sin,
                 };
-                let weights = self.layer_weights(layer_idx)?;
-                let (residual, mlp_out) = layer.forward(&input, &weights, &self.blas, prev_mlp_out.as_ref(), self.cublaslt_ref())?;
-                hidden_f16 = residual;
-                prev_mlp_out = Some(mlp_out);
+                hidden_states = if self.use_fp16 {
+                    let weights = self.layer_weights_f16(layer_idx)?;
+                    layer.forward_f16(&input, &weights, &self.blas)?
+                } else {
+                    let weights = self.layer_weights(layer_idx)?;
+                    layer.forward(&input, &weights, &self.blas)?
+                };
             }
 
-            // Final: fuse last layer's residual add with final RMSNorm
-            let normed_f16 = if let Some(ref last_mlp) = prev_mlp_out {
-                let (n, _) = GpuTransformerLayer::fused_residual_rmsnorm_f16(
-                    &self.stream, &self.loader,
-                    &hidden_f16, last_mlp, &self.final_norm_weight,
-                    self.rms_norm_eps, num_tokens, hidden_size,
-                )?;
-                n
-            } else {
-                self.rms_norm_f16_runner(&hidden_f16, &self.final_norm_weight, hidden_size)?
-            };
+            // Step 3: final RMSNorm
+            let normed = CudaRMSNorm::forward(
+                &hidden_states,
+                &self.final_norm_weight,
+                self.rms_norm_eps,
+                hidden_size,
+                &self.loader,
+                &self.stream,
+            )?;
 
-            // LM head + argmax: f16 hidden -> fused argmax
+            // Step 4+5: fused LM-head + argmax for single-token greedy decode
             if num_tokens == 1 && greedy_only {
-                let token_ids_gpu = self.gpu_fused_lm_head_argmax_f16_hidden(
-                    &normed_f16, &self.lm_head_weight, vocab_size, hidden_size)?;
-                let token_ids_cpu = self.stream.clone_dtoh(&token_ids_gpu)
+                let token_ids_gpu = if self.use_fp16 {
+                    let lm_f16 = self
+                        .weights
+                        .get_f16("lm_head.weight")
+                        .or_else(|| self.weights.get_f16("model.embed_tokens.weight"));
+                    if let Some(lm_w) = lm_f16 {
+                        self.gpu_fused_lm_head_argmax_f16(&normed, lm_w, vocab_size, hidden_size)?
+                    } else {
+                        self.gpu_fused_lm_head_argmax(&normed, &self.lm_head_weight, vocab_size, hidden_size)?
+                    }
+                } else {
+                    self.gpu_fused_lm_head_argmax(&normed, &self.lm_head_weight, vocab_size, hidden_size)?
+                };
+                let token_ids_cpu = self
+                    .stream
+                    .clone_dtoh(&token_ids_gpu)
                     .map_err(|e| LLMError::GpuError(format!("fused_lm_head token DtoH: {e}")))?;
                 return Ok(ForwardOutput::TokenIds(token_ids_cpu));
             }
 
-            // Full logits path: hgemm f16 hidden x f16 lm_head -> f32 logits
-            let logits_gpu = CudaLinearLayer::forward_f16_in(
-                &normed_f16, &self.lm_head_weight, num_tokens, vocab_size, hidden_size,
-                &self.blas,
-            )?;
+            // Step 4: LM head
+            let logits_gpu = if self.use_fp16 {
+                let lm_f16 = self
+                    .weights
+                    .get_f16("lm_head.weight")
+                    .or_else(|| self.weights.get_f16("model.embed_tokens.weight"));
+                if let Some(lm_w) = lm_f16 {
+                    CudaLinearLayer::forward_once_f16(
+                        &normed, lm_w, num_tokens, vocab_size, hidden_size, &self.blas, &self.loader,
+                    )?
+                } else {
+                    CudaLinearLayer::forward_once(
+                        &normed, &self.lm_head_weight, None,
+                        num_tokens, vocab_size, hidden_size, &self.blas,
+                    )?
+                }
+            } else {
+                CudaLinearLayer::forward_once(
+                    &normed, &self.lm_head_weight, None,
+                    num_tokens, vocab_size, hidden_size, &self.blas,
+                )?
+            };
 
+            // Step 5: greedy fast path
             if greedy_only {
                 let token_ids_gpu = self.gpu_argmax(&logits_gpu, num_tokens, vocab_size)?;
-                let token_ids_cpu = self.stream.clone_dtoh(&token_ids_gpu)
+                let token_ids_cpu = self
+                    .stream
+                    .clone_dtoh(&token_ids_gpu)
                     .map_err(|e| LLMError::GpuError(format!("argmax DtoH: {e}")))?;
                 return Ok(ForwardOutput::TokenIds(token_ids_cpu));
             }
 
-            let logits_cpu = self.stream.clone_dtoh(&logits_gpu)
+            // Full logits DtoH
+            let logits_cpu = self
+                .stream
+                .clone_dtoh(&logits_gpu)
                 .map_err(|e| LLMError::GpuError(format!("logits DtoH: {e}")))?;
             Ok(ForwardOutput::Logits(logits_cpu))
         }
@@ -791,14 +694,6 @@ mod cuda_impl {
         /// Get a reference to the CUDA stream used by this runner.
         pub fn cuda_stream(&self) -> &Arc<CudaStream> {
             &self.stream
-        }
-
-        /// Get cublasLt reference (None when feature is off).
-        fn cublaslt_ref(&self) -> Option<&crate::CublasLtRef> {
-            #[cfg(feature = "cublaslt")]
-            { self.blas_lt.as_ref() }
-            #[cfg(not(feature = "cublaslt"))]
-            { None }
         }
 
 
@@ -813,23 +708,6 @@ mod cuda_impl {
                     "GPU does not support async memory allocation (cuMemAllocAsync). \
                      CUDA graph capture may fail. Consider upgrading the CUDA driver."
                 );
-            }
-            // Pre-allocate the packed metadata buffer large enough for max batch size
-            // so it never reallocates (which would invalidate graph-captured pointers).
-            // Layout per step: token_ids(N) + positions(N) + context_lens(N) +
-            //   block_tables(N * graph_max_blocks) + slot_mapping(N) + seq_start_pos(N+1)
-            let max_seqs = 256usize; // must match max_num_seqs
-            let max_meta = max_seqs * (1 + 1 + 1 + self.graph_max_blocks + 1 + 1) + 1;
-            let mut meta = self.meta_packed.borrow_mut();
-            let dummy = vec![0i32; max_meta];
-            meta.upload(&dummy, &self.stream)
-                .map_err(|e| LLMError::GpuError(format!("pre-alloc meta: {e}")))?;
-            info!(max_meta, "pre-allocated packed metadata buffer for graph stability");
-            // Pre-allocate graph output buffer too (same reason -- stable pointer).
-            {
-                let mut out = self.graph_output.borrow_mut();
-                *out = Some(self.stream.alloc_zeros::<i32>(max_seqs)
-                    .map_err(|e| LLMError::GpuError(format!("pre-alloc graph_output: {e}")))?);
             }
             Ok(())
         }
@@ -857,62 +735,95 @@ mod cuda_impl {
                 return Err(LLMError::ModelError("empty input".into()));
             }
 
-            let mut hidden_f16 = self.embedding_lookup_from_meta(num_tokens)?;
+            let meta_pos = self.meta_positions.borrow();
+            let meta_cl = self.meta_context_lens.borrow();
+            let meta_bt = self.meta_block_tables.borrow();
+            let meta_sm = self.meta_slot_mapping.borrow();
+            let meta_ssp = self.meta_seq_start_pos.borrow();
 
+            // Step 1: token embedding lookup from persistent buffer
+            let mut hidden_states = self.embedding_lookup_from_meta(num_tokens)?;
+
+            // Step 2: transformer layers
             let gpu_cache = self.cache.gpu_cache();
             let num_layers = self.layers.len();
-            let meta_packed = self.meta_packed.borrow();
-            let packed_buf = meta_packed.slice();
-            let offsets = self.meta_packed_offsets.get();
-            // NOTE: No profiling in forward_gpu_only -- this is captured into CUDA graphs.
-            // stream.synchronize() during capture would invalidate the graph.
-            let mut prev_mlp_out: Option<CudaSlice<f16>> = None;
             for (layer_idx, layer) in self.layers.iter().enumerate() {
                 let (key_cache, value_cache) = &gpu_cache[layer_idx];
                 let input = GpuLayerInput {
-                    hidden_states: &hidden_f16,
-                    positions: packed_buf.slice(offsets.positions..offsets.positions + offsets.num_positions),
+                    hidden_states: &hidden_states,
+                    positions: meta_pos.slice(),
                     key_cache,
                     value_cache,
-                    block_tables: packed_buf.slice(offsets.block_tables..offsets.block_tables + offsets.num_block_tables),
-                    context_lens: packed_buf.slice(offsets.context_lens..offsets.context_lens + offsets.num_context_lens),
-                    slot_mapping: packed_buf.slice(offsets.slot_mapping..offsets.slot_mapping + offsets.num_slot_mapping),
+                    block_tables: meta_bt.slice(),
+                    context_lens: meta_cl.slice(),
+                    slot_mapping: meta_sm.slice(),
                     num_tokens,
                     num_seqs,
                     max_context_len,
                     block_size,
                     is_prefill,
-                    seq_start_pos: packed_buf.slice(offsets.seq_start_pos..offsets.seq_start_pos + offsets.num_seq_start_pos),
+                    seq_start_pos: meta_ssp.slice(),
                     rope_cos: &self.rope_cos,
                     rope_sin: &self.rope_sin,
                 };
-                let weights = self.layer_weights(layer_idx)?;
-                let (residual, mlp_out) = layer.forward(&input, &weights, &self.blas, prev_mlp_out.as_ref(), self.cublaslt_ref())?;
-                hidden_f16 = residual;
-                prev_mlp_out = Some(mlp_out);
+                hidden_states = if self.use_fp16 {
+                    let weights = self.layer_weights_f16(layer_idx)?;
+                    layer.forward_f16(&input, &weights, &self.blas)?
+                } else {
+                    let weights = self.layer_weights(layer_idx)?;
+                    layer.forward(&input, &weights, &self.blas)?
+                };
             }
 
-            // Final: fuse last layer's residual add with final RMSNorm
-            let normed_f16 = if let Some(ref last_mlp) = prev_mlp_out {
-                let (n, _) = GpuTransformerLayer::fused_residual_rmsnorm_f16(
-                    &self.stream, &self.loader,
-                    &hidden_f16, last_mlp, &self.final_norm_weight,
-                    self.rms_norm_eps, num_tokens, hidden_size,
-                )?;
-                n
-            } else {
-                self.rms_norm_f16_runner(&hidden_f16, &self.final_norm_weight, hidden_size)?
-            };
+            // Step 3: final RMSNorm
+            let normed = CudaRMSNorm::forward(
+                &hidden_states,
+                &self.final_norm_weight,
+                self.rms_norm_eps,
+                hidden_size,
+                &self.loader,
+                &self.stream,
+            )?;
 
+            // Step 4+5: fused LM-head + argmax into persistent output buffer
             let token_ids_gpu = if num_tokens == 1 {
-                self.gpu_fused_lm_head_argmax_f16_hidden(
-                    &normed_f16, &self.lm_head_weight, vocab_size, hidden_size)?
+                if self.use_fp16 {
+                    let lm_f16 = self
+                        .weights
+                        .get_f16("lm_head.weight")
+                        .or_else(|| self.weights.get_f16("model.embed_tokens.weight"));
+                    if let Some(lm_w) = lm_f16 {
+                        self.gpu_fused_lm_head_argmax_f16(&normed, lm_w, vocab_size, hidden_size)?
+                    } else {
+                        self.gpu_fused_lm_head_argmax(&normed, &self.lm_head_weight, vocab_size, hidden_size)?
+                    }
+                } else {
+                    self.gpu_fused_lm_head_argmax(&normed, &self.lm_head_weight, vocab_size, hidden_size)?
+                }
             } else {
-                // Multi-token: hgemm f16 hidden x f16 lm_head -> f32 logits -> argmax
-                let logits_gpu = CudaLinearLayer::forward_f16_in(
-                    &normed_f16, &self.lm_head_weight, num_tokens, vocab_size, hidden_size,
-                    &self.blas,
-                )?;
+                // Multi-token: full LM head then argmax
+                let logits_gpu = if self.use_fp16 {
+                    let lm_f16 = self
+                        .weights
+                        .get_f16("lm_head.weight")
+                        .or_else(|| self.weights.get_f16("model.embed_tokens.weight"));
+                    if let Some(lm_w) = lm_f16 {
+                        CudaLinearLayer::forward_once_f16(
+                            &normed, lm_w, num_tokens, vocab_size, hidden_size,
+                            &self.blas, &self.loader,
+                        )?
+                    } else {
+                        CudaLinearLayer::forward_once(
+                            &normed, &self.lm_head_weight, None,
+                            num_tokens, vocab_size, hidden_size, &self.blas,
+                        )?
+                    }
+                } else {
+                    CudaLinearLayer::forward_once(
+                        &normed, &self.lm_head_weight, None,
+                        num_tokens, vocab_size, hidden_size, &self.blas,
+                    )?
+                };
                 self.gpu_argmax(&logits_gpu, num_tokens, vocab_size)?
             };
 
@@ -948,33 +859,24 @@ mod cuda_impl {
             Ok(full[..num_tokens].to_vec())
         }
 
-        /// Enqueue an async DtoH copy of graph output into a pinned host buffer.
-        ///
-        /// Unlike `read_graph_output`, this does NOT synchronize the stream.
-        /// The caller must call `sync_stream()` before reading from `dst`.
-        /// `dst` MUST be pinned host memory for truly async behavior; with
-        /// pageable memory cuMemcpyDtoHAsync degrades to synchronous.
         pub fn read_graph_output_async(
             &self,
             num_tokens: usize,
             dst: &mut [i32],
         ) -> Result<()> {
-            let out = self.graph_output.borrow();
-            let buf = out.as_ref().ok_or_else(|| {
-                LLMError::GpuError("graph_output not populated -- call forward_gpu_only first".into())
-            })?;
-            // Only copy num_tokens elements (not the full padded buffer)
-            let src_view = buf.slice(..num_tokens);
-            self.stream.memcpy_dtoh(&src_view, &mut dst[..num_tokens])
-                .map_err(|e| LLMError::GpuError(format!("graph_output async DtoH: {e}")))?;
+            let ids = self.read_graph_output(num_tokens)?;
+            dst[..num_tokens].copy_from_slice(&ids[..num_tokens]);
             Ok(())
         }
 
-        /// Synchronize the runner's CUDA stream, blocking until all enqueued
-        /// work (graph replay + async DtoH) completes.
         pub fn sync_stream(&self) -> Result<()> {
-            self.stream.synchronize()
+            self.stream
+                .synchronize()
                 .map_err(|e| LLMError::GpuError(format!("stream sync: {e}")))?;
+            Ok(())
+        }
+
+        pub fn fuse_weights(&mut self) -> Result<()> {
             Ok(())
         }
 
@@ -1157,7 +1059,7 @@ mod cuda_impl {
 
         /// Per-layer weight references into the GPU weight map.
         fn layer_weights(&self, i: usize) -> Result<GpuLayerWeights<'_>> {
-            let g = |name: &str| -> Result<&CudaSlice<f16>> {
+            let g = |name: &str| -> Result<&CudaSlice<f32>> {
                 self.weights
                     .get(name)
                     .ok_or_else(|| LLMError::GpuError(format!("missing weight: {name}")))
@@ -1168,36 +1070,52 @@ mod cuda_impl {
                 k_proj: g(&format!("model.layers.{i}.self_attn.k_proj.weight"))?,
                 v_proj: g(&format!("model.layers.{i}.self_attn.v_proj.weight"))?,
                 o_proj: g(&format!("model.layers.{i}.self_attn.o_proj.weight"))?,
+                q_proj_bias: self
+                    .weights
+                    .get(&format!("model.layers.{i}.self_attn.q_proj.bias")),
+                k_proj_bias: self
+                    .weights
+                    .get(&format!("model.layers.{i}.self_attn.k_proj.bias")),
+                v_proj_bias: self
+                    .weights
+                    .get(&format!("model.layers.{i}.self_attn.v_proj.bias")),
                 post_attention_layernorm: g(&format!(
                     "model.layers.{i}.post_attention_layernorm.weight"
                 ))?,
-                gate_proj: g(&format!("model.layers.{i}.mlp.gate_proj.weight"))?,
-                up_proj: g(&format!("model.layers.{i}.mlp.up_proj.weight"))?,
-                down_proj: g(&format!("model.layers.{i}.mlp.down_proj.weight"))?,
-                fused_qkv: self.fused_qkv_weights.get(i),
-                fused_gate_up: self.fused_gate_up_weights.get(i),
-                qkv_bias: self.fused_qkv_bias.get(i).and_then(|o| o.as_ref()),
+                gate_proj: self.weights.get(&format!("model.layers.{i}.mlp.gate_proj.weight")),
+                up_proj: self.weights.get(&format!("model.layers.{i}.mlp.up_proj.weight")),
+                down_proj: self.weights.get(&format!("model.layers.{i}.mlp.down_proj.weight")),
+                gpt_oss_moe: self.gpt_oss_moe_layers[i].as_ref(),
             })
         }
 
-        /// Embedding lookup using the pre-uploaded token IDs in the packed
-        /// metadata buffer. Call upload_metadata() first to populate.
-        fn embedding_lookup_from_meta(&self, num_tokens: usize) -> Result<CudaSlice<f16>> {
+        fn embedding_lookup(&self, token_ids: &[u32]) -> Result<CudaSlice<f32>> {
+            // Upload token IDs into persistent buffer (stable pointer for graph replay).
+            {
+                let mut scratch = self.cpu_scratch.borrow_mut();
+                scratch.clear();
+                scratch.extend(token_ids.iter().map(|&t| t as i32));
+                self.meta_token_ids.borrow_mut().upload(&scratch, &self.stream)
+                    .map_err(|e| LLMError::GpuError(format!("token_ids HtoD: {e}")))?;
+            }
+            self.embedding_lookup_from_meta(token_ids.len())
+        }
+
+        /// Embedding lookup using the pre-uploaded token IDs in meta_token_ids.
+        /// Call upload_metadata() first to populate the buffer.
+        fn embedding_lookup_from_meta(&self, num_tokens: usize) -> Result<CudaSlice<f32>> {
             let hidden_size = self.config.hidden_size;
 
-            let kernel = self.loader
-                .get_func("embedding_gather_f16", "embedding_gather_f16_kernel")?;
+            let kernel = self
+                .loader
+                .get_func("embedding_gather", "embedding_gather_kernel")?;
 
-            // Safety: embedding gather kernel writes all num_tokens * hidden_size elements
-            let output = unsafe { self.stream.alloc::<f16>(num_tokens * hidden_size) }
+            let output = self
+                .stream
+                .alloc_zeros::<f32>(num_tokens * hidden_size)
                 .map_err(|e| LLMError::GpuError(format!("embed alloc: {e}")))?;
 
-            let meta_packed = self.meta_packed.borrow();
-            let packed_buf = meta_packed.slice();
-            let offsets = self.meta_packed_offsets.get();
-            let token_ids_view = packed_buf.slice(
-                offsets.token_ids..offsets.token_ids + offsets.num_token_ids,
-            );
+            let meta_tid = self.meta_token_ids.borrow();
 
             let block_dim = hidden_size.min(1024) as u32;
             let cfg = LaunchConfig {
@@ -1211,7 +1129,7 @@ mod cuda_impl {
                     .launch_builder(&kernel)
                     .arg(&output)
                     .arg(&self.embed_tokens)
-                    .arg(&token_ids_view)
+                    .arg(meta_tid.slice())
                     .arg(&(hidden_size as i32))
                     .arg(&(self.config.vocab_size as i32))
                     .launch(cfg)
@@ -1219,98 +1137,6 @@ mod cuda_impl {
             }
 
             Ok(output)
-        }
-
-        /// RMSNorm f16: f16 input, f16 weight, f16 output.
-        fn rms_norm_f16_runner(
-            &self,
-            input: &CudaSlice<f16>,
-            weight: &CudaSlice<f16>,
-            hidden_size: usize,
-        ) -> Result<CudaSlice<f16>> {
-            let num_tokens = input.len() / hidden_size;
-            // Safety: rms_norm kernel writes all elements
-            let mut output = unsafe { self.stream.alloc::<f16>(input.len()) }
-                .map_err(|e| LLMError::GpuError(format!("rms_norm_f16 alloc: {e}")))?;
-            let block_threads = hidden_size.min(1024) as u32;
-            let cfg = LaunchConfig {
-                grid_dim: (num_tokens as u32, 1, 1),
-                block_dim: (block_threads, 1, 1),
-                shared_mem_bytes: block_threads * std::mem::size_of::<f32>() as u32,
-            };
-            let kernel = self.loader.get_func("rms_norm_f16", "rms_norm_f16_kernel")?;
-            unsafe {
-                self.stream.launch_builder(&kernel)
-                    .arg(&mut output)
-                    .arg(input)
-                    .arg(weight)
-                    .arg(&self.rms_norm_eps)
-                    .arg(&(hidden_size as i32))
-                    .launch(cfg)
-                    .map_err(|e| LLMError::GpuError(format!("rms_norm_f16 launch: {e}")))?;
-            }
-            Ok(output)
-        }
-
-        /// In-place RMSNorm f16: normalizes `input` directly, no output allocation.
-        fn rms_norm_f16_inplace_runner(
-            &self,
-            input: &mut CudaSlice<f16>,
-            weight: &CudaSlice<f16>,
-            hidden_size: usize,
-        ) -> Result<()> {
-            let num_tokens = input.len() / hidden_size;
-            let block_threads = hidden_size.min(1024) as u32;
-            let cfg = LaunchConfig {
-                grid_dim: (num_tokens as u32, 1, 1),
-                block_dim: (block_threads, 1, 1),
-                shared_mem_bytes: block_threads * std::mem::size_of::<f32>() as u32,
-            };
-            let kernel = self.loader.get_func("rms_norm_f16", "rms_norm_f16_kernel")?;
-            unsafe {
-                let (raw_ptr, _guard) = DevicePtrMut::device_ptr_mut(input, &self.stream);
-                self.stream.launch_builder(&kernel)
-                    .arg(&raw_ptr)
-                    .arg(&raw_ptr)
-                    .arg(weight)
-                    .arg(&self.rms_norm_eps)
-                    .arg(&(hidden_size as i32))
-                    .launch(cfg)
-                    .map_err(|e| LLMError::GpuError(format!("rms_norm_f16_inplace launch: {e}")))?;
-            }
-            Ok(())
-        }
-
-        /// Fused LM-head matvec + argmax for single-token greedy decode (f16 weights, f16 hidden).
-        /// Casts f16 hidden -> f32 internally since the kernel expects f32 hidden.
-        fn gpu_fused_lm_head_argmax_f16_hidden(
-            &self,
-            hidden_state_f16: &CudaSlice<f16>,
-            weight: &CudaSlice<f16>,
-            vocab_size: usize,
-            hidden_size: usize,
-        ) -> Result<CudaSlice<i32>> {
-            // Cast f16 hidden -> f32 for the LM head kernel
-            let cast_kernel = self.loader.get_func("cast_fp", "cast_f16_to_f32_kernel")?;
-            // Safety: cast kernel writes all hidden_size elements
-            let mut hidden_f32 = unsafe { self.stream.alloc::<f32>(hidden_size) }
-                .map_err(|e| LLMError::GpuError(format!("lm_head f16->f32 alloc: {e}")))?;
-            let threads = 256u32;
-            let blocks = ((hidden_size as u32) + threads - 1) / threads;
-            let cfg = LaunchConfig {
-                grid_dim: (blocks, 1, 1),
-                block_dim: (threads, 1, 1),
-                shared_mem_bytes: 0,
-            };
-            unsafe {
-                self.stream.launch_builder(&cast_kernel)
-                    .arg(&mut hidden_f32)
-                    .arg(hidden_state_f16)
-                    .arg(&(hidden_size as i32))
-                    .launch(cfg)
-                    .map_err(|e| LLMError::GpuError(format!("lm_head f16->f32 launch: {e}")))?;
-            }
-            self.gpu_fused_lm_head_argmax_f16(&hidden_f32, weight, vocab_size, hidden_size)
         }
 
         pub fn config(&self) -> &ModelRunnerConfig {
@@ -1325,6 +1151,288 @@ mod cuda_impl {
             &mut self.cache
         }
 
+        /// Enable f16 inference mode.
+        ///
+        /// After calling this, `forward_ex` will use hgemm with f16 projection
+        /// weights for all linear layers. The `GpuModelWeights` must already
+        /// have f16 weights populated via `insert_f16` / the f16 loader.
+        pub fn enable_fp16(&mut self) {
+            self.use_fp16 = true;
+            info!(use_fp16 = true, "GpuModelRunner: fp16 mode enabled");
+        }
+
+        pub fn use_fp16(&self) -> bool {
+            self.use_fp16
+        }
+
+        pub fn supports_cuda_graphs(&self) -> bool {
+            if self.config.architecture != "GptOssForCausalLM" {
+                return true;
+            }
+            self.use_fp16
+                && self
+                    .gpt_oss_moe_layers
+                    .iter()
+                    .flatten()
+                    .all(|layer| layer.supports_gpu_decode())
+        }
+
+        pub fn prepare_gpt_oss_graph_decode(&mut self) -> Result<()> {
+            if self.config.architecture != "GptOssForCausalLM" || !self.use_fp16 {
+                return Ok(());
+            }
+
+            self.prune_fp32_projection_weights_for_fp16();
+
+            for i in 0..self.gpt_oss_moe_layers.len() {
+                let Some(layer) = self.gpt_oss_moe_layers[i].as_mut() else {
+                    continue;
+                };
+                if layer.supports_gpu_decode() {
+                    continue;
+                }
+
+                let prefix = format!("model.layers.{i}.mlp.experts");
+                let gate_up_blocks_name = format!("{prefix}.gate_up_proj_blocks");
+                let gate_up_scales_name = format!("{prefix}.gate_up_proj_scales");
+                let down_blocks_name = format!("{prefix}.down_proj_blocks");
+                let down_scales_name = format!("{prefix}.down_proj_scales");
+
+                if layer.gate_up_blocks_gpu.is_none() {
+                    let data = self.weights.get_u8(&gate_up_blocks_name).ok_or_else(|| {
+                        LLMError::GpuError(format!("missing GPT-OSS weight: {gate_up_blocks_name}"))
+                    })?;
+                    layer.gate_up_blocks_gpu = Some(
+                        self.stream.clone_htod(data).map_err(|e| {
+                            LLMError::GpuError(format!("HtoD {gate_up_blocks_name}: {e}"))
+                        })?,
+                    );
+                }
+                if layer.gate_up_scales_gpu.is_none() {
+                    let data = self.weights.get_u8(&gate_up_scales_name).ok_or_else(|| {
+                        LLMError::GpuError(format!("missing GPT-OSS weight: {gate_up_scales_name}"))
+                    })?;
+                    layer.gate_up_scales_gpu = Some(
+                        self.stream.clone_htod(data).map_err(|e| {
+                            LLMError::GpuError(format!("HtoD {gate_up_scales_name}: {e}"))
+                        })?,
+                    );
+                }
+                if layer.down_blocks_gpu.is_none() {
+                    let data = self.weights.get_u8(&down_blocks_name).ok_or_else(|| {
+                        LLMError::GpuError(format!("missing GPT-OSS weight: {down_blocks_name}"))
+                    })?;
+                    layer.down_blocks_gpu = Some(
+                        self.stream.clone_htod(data).map_err(|e| {
+                            LLMError::GpuError(format!("HtoD {down_blocks_name}: {e}"))
+                        })?,
+                    );
+                }
+                if layer.down_scales_gpu.is_none() {
+                    let data = self.weights.get_u8(&down_scales_name).ok_or_else(|| {
+                        LLMError::GpuError(format!("missing GPT-OSS weight: {down_scales_name}"))
+                    })?;
+                    layer.down_scales_gpu = Some(
+                        self.stream.clone_htod(data).map_err(|e| {
+                            LLMError::GpuError(format!("HtoD {down_scales_name}: {e}"))
+                        })?,
+                    );
+                }
+            }
+
+            Ok(())
+        }
+
+        fn prune_fp32_projection_weights_for_fp16(&mut self) {
+            if self.config.architecture != "GptOssForCausalLM" || !self.use_fp16 {
+                return;
+            }
+
+            let mut removed = 0usize;
+            for i in 0..self.config.num_layers {
+                for suffix in [
+                    "self_attn.q_proj.weight",
+                    "self_attn.k_proj.weight",
+                    "self_attn.v_proj.weight",
+                    "self_attn.o_proj.weight",
+                    "mlp.gate_proj.weight",
+                    "mlp.up_proj.weight",
+                    "mlp.down_proj.weight",
+                    "mlp.router.weight",
+                    "mlp.router.bias",
+                ] {
+                    let name = format!("model.layers.{i}.{suffix}");
+                    if self.weights.remove(&name).is_some() {
+                        removed += 1;
+                    }
+                }
+                for suffix in [
+                    "mlp.gate_proj.weight",
+                    "mlp.up_proj.weight",
+                    "mlp.down_proj.weight",
+                ] {
+                    let name = format!("model.layers.{i}.{suffix}");
+                    if self.weights.remove_f16(&name).is_some() {
+                        removed += 1;
+                    }
+                }
+            }
+
+            for shared in ["model.embed_tokens.weight", "lm_head.weight"] {
+                if self.weights.remove(shared).is_some() {
+                    removed += 1;
+                }
+                if self.weights.remove_f16(shared).is_some() {
+                    removed += 1;
+                }
+            }
+
+            if removed > 0 {
+                info!(removed, "pruned unused GPT-OSS fp32 projection weights after enabling fp16");
+            }
+        }
+
+        /// Per-layer f16 weight references into the GPU weight map.
+        fn layer_weights_f16(&self, i: usize) -> Result<GpuLayerWeightsF16<'_>> {
+            let g_f16 = |name: &str| -> Result<&CudaSlice<f16>> {
+                self.weights
+                    .get_f16(name)
+                    .ok_or_else(|| LLMError::GpuError(format!("missing f16 weight: {name}")))
+            };
+            let g_f32 = |name: &str| -> Result<&CudaSlice<f32>> {
+                self.weights
+                    .get(name)
+                    .ok_or_else(|| LLMError::GpuError(format!("missing weight: {name}")))
+            };
+            Ok(GpuLayerWeightsF16 {
+                input_layernorm: g_f32(&format!("model.layers.{i}.input_layernorm.weight"))?,
+                q_proj: g_f16(&format!("model.layers.{i}.self_attn.q_proj.weight"))?,
+                k_proj: g_f16(&format!("model.layers.{i}.self_attn.k_proj.weight"))?,
+                v_proj: g_f16(&format!("model.layers.{i}.self_attn.v_proj.weight"))?,
+                o_proj: g_f16(&format!("model.layers.{i}.self_attn.o_proj.weight"))?,
+                q_proj_bias: self
+                    .weights
+                    .get(&format!("model.layers.{i}.self_attn.q_proj.bias")),
+                k_proj_bias: self
+                    .weights
+                    .get(&format!("model.layers.{i}.self_attn.k_proj.bias")),
+                v_proj_bias: self
+                    .weights
+                    .get(&format!("model.layers.{i}.self_attn.v_proj.bias")),
+                post_attention_layernorm: g_f32(&format!(
+                    "model.layers.{i}.post_attention_layernorm.weight"
+                ))?,
+                gate_proj: self.weights.get_f16(&format!("model.layers.{i}.mlp.gate_proj.weight")),
+                up_proj: self.weights.get_f16(&format!("model.layers.{i}.mlp.up_proj.weight")),
+                down_proj: self.weights.get_f16(&format!("model.layers.{i}.mlp.down_proj.weight")),
+                gpt_oss_moe: self.gpt_oss_moe_layers[i].as_ref(),
+            })
+        }
+
+        fn build_gpt_oss_moe_layers(
+            weights: &GpuModelWeights,
+            config: &ModelRunnerConfig,
+            stream: &Arc<CudaStream>,
+        ) -> Result<Vec<Option<GptOssMoeLayerWeights>>> {
+            if config.architecture != "GptOssForCausalLM" {
+                return Ok((0..config.num_layers).map(|_| None).collect());
+            }
+
+            let mut layers = Vec::with_capacity(config.num_layers);
+            for i in 0..config.num_layers {
+                let prefix = format!("model.layers.{i}.mlp.experts");
+                let gate_up_blocks_name = format!("{prefix}.gate_up_proj_blocks");
+                let down_blocks_name = format!("{prefix}.down_proj_blocks");
+
+                let Some(gate_up_blocks) = weights.get_u8(&gate_up_blocks_name) else {
+                    layers.push(None);
+                    continue;
+                };
+                let down_blocks = weights.get_u8(&down_blocks_name).ok_or_else(|| {
+                    LLMError::GpuError(format!("missing GPT-OSS weight: {down_blocks_name}"))
+                })?;
+                let gate_up_scales_name = format!("{prefix}.gate_up_proj_scales");
+                let down_scales_name = format!("{prefix}.down_proj_scales");
+                let gate_up_scales = weights.get_u8(&gate_up_scales_name).ok_or_else(|| {
+                    LLMError::GpuError(format!("missing GPT-OSS weight: {gate_up_scales_name}"))
+                })?;
+                let down_scales = weights.get_u8(&down_scales_name).ok_or_else(|| {
+                    LLMError::GpuError(format!("missing GPT-OSS weight: {down_scales_name}"))
+                })?;
+
+                let dtoh = |name: &str| -> Result<Vec<f32>> {
+                    let weight = weights
+                        .get(name)
+                        .ok_or_else(|| LLMError::GpuError(format!("missing weight: {name}")))?;
+                    stream
+                        .clone_dtoh(weight)
+                        .map_err(|e| LLMError::GpuError(format!("DtoH {name}: {e}")))
+                };
+                let router_weight_name = format!("model.layers.{i}.mlp.router.weight");
+                let router_bias_name = format!("model.layers.{i}.mlp.router.bias");
+                let gate_up_bias_host = dtoh(&format!("{prefix}.gate_up_proj_bias"))?;
+                let down_bias_host = dtoh(&format!("{prefix}.down_proj_bias"))?;
+                let gate_up_bias_gpu = gate_up_bias_host
+                    .chunks(config.intermediate_size * 2)
+                    .map(|chunk| {
+                        stream
+                            .clone_htod(chunk)
+                            .map_err(|e| LLMError::GpuError(format!("HtoD gate_up bias layer {i}: {e}")))
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+                let down_bias_gpu = down_bias_host
+                    .chunks(config.hidden_size)
+                    .map(|chunk| {
+                        stream
+                            .clone_htod(chunk)
+                            .map_err(|e| LLMError::GpuError(format!("HtoD down bias layer {i}: {e}")))
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+
+                layers.push(Some(GptOssMoeLayerWeights {
+                    router_weight: dtoh(&router_weight_name)?,
+                    router_bias: dtoh(&router_bias_name)?,
+                    gate_up_blocks: gate_up_blocks.to_vec(),
+                    gate_up_scales: gate_up_scales.to_vec(),
+                    gate_up_bias: gate_up_bias_host,
+                    down_blocks: down_blocks.to_vec(),
+                    down_scales: down_scales.to_vec(),
+                    down_bias: down_bias_host,
+                    hidden_size: config.hidden_size,
+                    intermediate_size: config.intermediate_size,
+                    num_local_experts: config.num_local_experts,
+                    num_experts_per_tok: config.num_experts_per_tok,
+                    router_weight_gpu: Some(
+                        weights
+                            .get(&router_weight_name)
+                            .ok_or_else(|| {
+                                LLMError::GpuError(format!(
+                                    "missing GPT-OSS weight: {router_weight_name}"
+                                ))
+                            })?
+                            .clone(),
+                    ),
+                    router_bias_gpu: Some(
+                        weights
+                            .get(&router_bias_name)
+                            .ok_or_else(|| {
+                                LLMError::GpuError(format!(
+                                    "missing GPT-OSS weight: {router_bias_name}"
+                                ))
+                            })?
+                            .clone(),
+                    ),
+                    gate_up_blocks_gpu: None,
+                    gate_up_scales_gpu: None,
+                    gate_up_bias_gpu: Some(gate_up_bias_gpu),
+                    down_blocks_gpu: None,
+                    down_scales_gpu: None,
+                    down_bias_gpu: Some(down_bias_gpu),
+                }));
+            }
+
+            Ok(layers)
+        }
     }
 }
 
@@ -1422,18 +1530,11 @@ mod mock_impl {
             ))
         }
 
-        pub fn read_graph_output_async(&self, _dst: &mut [i32]) -> Result<()> {
-            Err(LLMError::GpuError(
-                "GpuModelRunner requires the `cuda` feature".into(),
-            ))
-        }
+        pub fn enable_fp16(&mut self) {}
 
-        pub fn sync_stream(&self) -> Result<()> {
-            Err(LLMError::GpuError(
-                "GpuModelRunner requires the `cuda` feature".into(),
-            ))
+        pub fn use_fp16(&self) -> bool {
+            false
         }
-
     }
 }
 
@@ -1446,6 +1547,7 @@ pub use mock_impl::GpuModelRunner;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rvllm_core::types::Dtype;
 
     #[test]
     fn mock_runner_returns_error() {
@@ -1460,8 +1562,16 @@ mod tests {
                 intermediate_size: 128,
                 vocab_size: 100,
                 max_position: 512,
-                rms_norm_eps: 1e-5, rope_theta: 10000.0,
-                dtype: "float32".to_string(),
+                rms_norm_eps: 1e-5,
+                rope_theta: 10000.0,
+                partial_rotary_factor: 1.0,
+                attn_logit_softcapping: 0.0,
+                attention_bias: false,
+                sliding_window: None,
+                layer_types: Vec::new(),
+                num_local_experts: 0,
+                num_experts_per_tok: 0,
+                dtype: Dtype::Float32,
                 architecture: "LlamaForCausalLM".to_string(),
             };
             let runner = GpuModelRunner { config };
@@ -1485,8 +1595,16 @@ mod tests {
                 intermediate_size: 512,
                 vocab_size: 32000,
                 max_position: 2048,
-                rms_norm_eps: 1e-5, rope_theta: 10000.0,
-                dtype: "float16".to_string(),
+                rms_norm_eps: 1e-5,
+                rope_theta: 10000.0,
+                partial_rotary_factor: 1.0,
+                attn_logit_softcapping: 0.0,
+                attention_bias: false,
+                sliding_window: None,
+                layer_types: Vec::new(),
+                num_local_experts: 0,
+                num_experts_per_tok: 0,
+                dtype: Dtype::Float16,
                 architecture: "LlamaForCausalLM".to_string(),
             };
             let runner = GpuModelRunner { config };

--- a/crates/rvllm-model-runner/src/runner.rs
+++ b/crates/rvllm-model-runner/src/runner.rs
@@ -24,6 +24,13 @@ pub struct ModelRunnerConfig {
     pub max_position: usize,
     pub rms_norm_eps: f32,
     pub rope_theta: f32,
+    pub partial_rotary_factor: f32,
+    pub attn_logit_softcapping: f32,
+    pub attention_bias: bool,
+    pub sliding_window: Option<usize>,
+    pub layer_types: Vec<String>,
+    pub num_local_experts: usize,
+    pub num_experts_per_tok: usize,
     pub dtype: Dtype,
     pub architecture: String,
 }

--- a/crates/rvllm-worker/src/config.rs
+++ b/crates/rvllm-worker/src/config.rs
@@ -45,6 +45,12 @@ pub struct WorkerConfig {
     pub partial_rotary_factor: f32,
     /// Soft-capping value for attention logits (Gemma 2). 0.0 = disabled.
     pub attn_logit_softcapping: f32,
+    /// Whether attention projections include biases.
+    pub attention_bias: bool,
+    /// Sliding-window size for architectures that alternate local/global attention.
+    pub sliding_window: Option<usize>,
+    /// Per-layer attention mode names from the HF config.
+    pub layer_types: Vec<String>,
     /// Number of MoE experts (Mixtral: 8, DeepSeek: 64). 0 = dense.
     pub num_local_experts: usize,
     /// Number of experts activated per token (Mixtral: 2, DeepSeek: 6).
@@ -71,6 +77,13 @@ impl WorkerConfig {
             dtype: self.dtype,
             architecture: self.architecture.clone(),
             rope_theta: self.rope_theta,
+            partial_rotary_factor: self.partial_rotary_factor,
+            attn_logit_softcapping: self.attn_logit_softcapping,
+            attention_bias: self.attention_bias,
+            sliding_window: self.sliding_window,
+            layer_types: self.layer_types.clone(),
+            num_local_experts: self.num_local_experts,
+            num_experts_per_tok: self.num_experts_per_tok,
         }
     }
 

--- a/crates/rvllm-worker/src/gpu_worker.rs
+++ b/crates/rvllm-worker/src/gpu_worker.rs
@@ -331,7 +331,11 @@ pub struct GpuWorker {
     vocab_table: Option<VocabTable>,
     /// Raw f16 weight map preserved for deferred GpuModelRunner construction.
     #[cfg(feature = "cuda")]
-    raw_weight_map: Option<HashMap<String, CudaSlice<half::f16>>>,
+    raw_weight_map: Option<HashMap<String, CudaSlice<f32>>>,
+    #[cfg(feature = "cuda")]
+    raw_weight_shapes: Option<HashMap<String, Vec<usize>>>,
+    #[cfg(feature = "cuda")]
+    raw_weight_map_f16: Option<HashMap<String, CudaSlice<half::f16>>>,
     /// GPU-resident model runner (full forward pass on GPU, no CPU attention fallback).
     /// Constructed in init_cache() once cache geometry is known.
     #[cfg(feature = "cuda")]
@@ -428,6 +432,7 @@ impl GpuWorker {
             vocab_size: config.vocab_size,
             hidden_size: config.hidden_size,
         });
+        let rms_norm_eps = config.rms_norm_eps;
 
         Ok(Self {
             context,
@@ -442,7 +447,7 @@ impl GpuWorker {
             runner_config: None,
             vocab_size: 0,
             model_weights: None,
-            rms_norm_eps: 1e-6,
+            rms_norm_eps,
             rope_table: None,
             kv_cache: None,
             fp8_kv_cache: None,
@@ -451,6 +456,10 @@ impl GpuWorker {
             vocab_table: None,
             #[cfg(feature = "cuda")]
             raw_weight_map: None,
+            #[cfg(feature = "cuda")]
+            raw_weight_shapes: None,
+            #[cfg(feature = "cuda")]
+            raw_weight_map_f16: None,
             #[cfg(feature = "cuda")]
             gpu_model_runner: None,
             graph_runner,
@@ -474,15 +483,31 @@ impl GpuWorker {
     pub fn load_weights(&mut self, model_path: &Path) -> Result<()> {
         info!(device_id = self.device_id, path = %model_path.display(), "loading weights to GPU");
 
-        let all_weights_f16 =
-            rvllm_model_loader::gpu_loader::load_weights_to_gpu(model_path, &self.stream)
+        let (all_weights_full, all_weight_shapes) =
+            rvllm_model_loader::gpu_loader::load_weights_to_gpu_with_shapes(
+                model_path,
+                &self.stream,
+            )
                 .map_err(|e| LLMError::GpuError(format!("weight loading failed: {e}")))?;
 
-        info!("loaded {} weight tensors to GPU (f16)", all_weights_f16.len());
+        info!("loaded {} weight tensors to GPU", all_weights_full.len());
 
         #[cfg(feature = "cuda")]
         {
-            self.raw_weight_map = Some(all_weights_f16.clone());
+            self.raw_weight_map = Some(all_weights_full.clone());
+            self.raw_weight_shapes = Some(all_weight_shapes.clone());
+
+            // Also load f16 weights for hgemm path when dtype is half
+            if self.config.dtype.is_half() {
+                info!("loading f16 weights for hgemm path");
+                let f16_weights = rvllm_model_loader::gpu_loader::load_weights_to_gpu_f16(
+                    model_path,
+                    &self.stream,
+                )
+                .map_err(|e| LLMError::GpuError(format!("f16 weight loading failed: {e}")))?;
+                info!("loaded {} f16 weight tensors", f16_weights.len());
+                self.raw_weight_map_f16 = Some(f16_weights);
+            }
         }
 
         // Weights are stored only in raw_weight_map for GpuModelRunner.
@@ -548,7 +573,19 @@ impl GpuWorker {
             let raw_map = self.raw_weight_map.take().ok_or_else(|| {
                 LLMError::GpuError("raw weight map not available -- call load_weights first".into())
             })?;
-            let loader_weights = LoaderWeights::new(raw_map, HashMap::new());
+            let raw_shapes = self.raw_weight_shapes.take().ok_or_else(|| {
+                LLMError::GpuError("raw weight shapes not available -- call load_weights first".into())
+            })?;
+            let mut loader_weights = LoaderWeights::new(raw_map, raw_shapes.clone());
+
+            // Insert f16 weights for hgemm path
+            if let Some(f16_map) = self.raw_weight_map_f16.take() {
+                for (name, slice) in f16_map {
+                    let shape = raw_shapes.get(&name).cloned().unwrap_or_default();
+                    loader_weights.insert_f16(name, slice, shape);
+                }
+                info!("inserted f16 weights into model weight container");
+            }
 
             let block_size = self.config.block_size;
             let cache = rvllm_kv_cache::engine_cuda::CudaCacheEngine::new(
@@ -590,8 +627,21 @@ impl GpuWorker {
                 self.stream.clone(),
             )?;
 
-            if let Err(e) = runner.fuse_weights() {
-                warn!("weight fusion failed: {e} -- f16 unfused path");
+            if self.config.dtype.is_half() {
+                runner.enable_fp16();
+                info!("FP16 inference enabled (hgemm path)");
+                // GPT-OSS decode uses a custom MoE path and does not have dense
+                // gate/up projections, so the generic fusion pass can leave a
+                // partially fused runner state. Keep GPT-OSS on the unfused path.
+                if self.config.architecture == "GptOssForCausalLM" {
+                    info!("skipping generic weight fusion for GPT-OSS");
+                    if let Err(e) = runner.prepare_gpt_oss_graph_decode() {
+                        warn!("GPT-OSS graph decode prep failed: {e} -- graph capture disabled");
+                        self.graph_runner.disable();
+                    }
+                } else if let Err(e) = runner.fuse_weights() {
+                    warn!("weight fusion failed: {e} -- using unfused path");
+                }
             }
 
             // Pre-allocate cuBLAS workspace for CUDA graph capture.
@@ -599,6 +649,13 @@ impl GpuWorker {
             if let Err(e) = runner.prepare_for_graph_capture() {
                 warn!("cuBLAS graph workspace setup failed: {e} -- graph capture disabled");
                 self.graph_runner.pool_mut().disable();
+            }
+
+            if !runner.supports_cuda_graphs() {
+                info!(
+                    "disabling CUDA graph replay for GPT-OSS: decode path is not graph-safe"
+                );
+                self.graph_runner.disable();
             }
 
 
@@ -1643,6 +1700,7 @@ fn worker_config_from_engine(
         intermediate_size: 11008,
         vocab_size: 32000,
         max_model_len: config.model.max_model_len,
+        rms_norm_eps: 1e-5,
         block_size: config.cache.block_size,
         gpu_memory_utilization: config.cache.gpu_memory_utilization,
         rank: 0,
@@ -1650,11 +1708,14 @@ fn worker_config_from_engine(
         pipeline_parallel_size: config.parallel.pipeline_parallel_size,
         architecture: "llama".into(),
         dtype: config.model.dtype.clone(),
-        rms_norm_eps: 1e-5, rope_theta: 10000.0,
+        rope_theta: 10000.0,
         kv_cache_dtype: config.cache.kv_cache_dtype.clone(),
         enable_prefix_caching: config.cache.enable_prefix_caching,
         partial_rotary_factor: 1.0,
         attn_logit_softcapping: 0.0,
+        attention_bias: false,
+        sliding_window: None,
+        layer_types: Vec::new(),
         num_local_experts: 0,
         num_experts_per_tok: 0,
     }


### PR DESCRIPTION
## Summary

Add CUDA runtime support for `GptOssForCausalLM` / `openai/gpt-oss-20b`.

This PR:
- adds GPT-OSS config parsing and transport through engine -> worker -> runner
- adds a real GPT-OSS architecture module and GPT-OSS-specific weight plumbing
- preserves GPT-OSS tensor shapes and `U8` MXFP4 expert payloads during loading
- adds sink-aware alternating sliding/full attention support in the CUDA path
- adds executable GPT-OSS MXFP4 expert routing / expert projection support
- fixes the GPT-OSS flash-attention launch packing bug that caused illegal KV-cache reads at runtime
- fixes post-merge GPT-OSS runtime fallout in fp16 setup and PTX discovery so the merged CUDA path still boots and serves

## Why

`openai/gpt-oss-20b` was recognized but not executable. The missing pieces were:
- config/model metadata transport for GPT-OSS-specific fields
- weight loading that preserves MXFP4 expert tensors and shape metadata
- runtime support for sink logits and alternating sliding/full attention
- executable GPT-OSS MoE routing and MXFP4 expert projections
- correct runtime handling for GPT-OSS-specific decode constraints

The late runtime bug fixed in this stack was a host/kernel argument mismatch after the flash-attention CUDA signature gained sink/sliding parameters. The Rust launch code still used the old argument order, which led to invalid KV-cache reads and illegal-address faults during layer-0 prefill.

## Impact

- `openai/gpt-oss-20b` now loads and serves through the CUDA engine path.
- GPT-OSS is now documented in the README supported-architectures table.
- CPU/mock GPT-OSS remains intentionally limited and still reports targeted unsupported errors there.

## Validation

Automated:
- `cargo test -p rvllm-model-runner gpt_oss --lib`
- `cargo test -p rvllm-model-runner gpt_oss_moe_forward_mxfp4_smoke --lib --features cuda`
- `cargo test -p rvllm-worker --features cuda gpt_oss_disables_cuda_graphs --lib`
- `cargo check -p rvllm-model-runner --features cuda`
- `cargo check -p rvllm-worker --features cuda`
- `cargo check -p rvllm-engine --features cuda`
- `cargo build -p rvllm-server --features cuda`
- `cargo build --release -p rvllm-server --features cuda`

Manual runtime validation against local weights at `/data/models/openai/gpt-oss-20b`:
- `target/release/rvllm serve --model /data/models/openai/gpt-oss-20b --host 127.0.0.1 --port 8010 --max-model-len 2048 --gpu-memory-utilization 0.90 --log-level info`
- `GET /health` returned `ok`
- `GET /v1/models` returned `/data/models/openai/gpt-oss-20b`
- `POST /v1/chat/completions` completed successfully end-to-end on the GPT-OSS path

## Current limitation

On the validated local single-GPU 24 GB RTX 3090 setup, GPT-OSS decode does not currently use CUDA graph replay. During GPT-OSS graph-decode preparation, expert tensor upload still fails with `CUDA_ERROR_OUT_OF_MEMORY` (`model.layers.23.mlp.experts.down_proj_blocks` in the observed run), so the worker disables graph replay and falls back to eager decode. The model still serves correctly in that mode, but this PR does not yet make GPT-OSS graph-safe on that VRAM budget.
