### PR TITLE
Expand Responses API compatibility support

### DIFF
--- a/crates/rvllm-api/src/routes/responses.rs
+++ b/crates/rvllm-api/src/routes/responses.rs
@@ -1344,7 +1344,7 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use crate::types::responses::{
-        ResponseInputMessage, ResponseInputTextPart, ResponseSpecificToolChoice,
+        ResponseInputContentPart, ResponseInputMessage, ResponseSpecificToolChoice,
     };
     use crate::{build_router, AppState};
     use axum_test::TestServer;
@@ -1576,7 +1576,7 @@ mod tests {
         let items = vec![
             StoredConversationItem::Input(ResponseInputItem::Message(ResponseInputMessage::new(
                 "user",
-                vec![ResponseInputTextPart::new("Weather?")],
+                vec![ResponseInputContentPart::input_text("Weather?")],
             ))),
             StoredConversationItem::Output(ResponseOutputItem::FunctionCall(
                 ResponseFunctionCallItem::completed(
@@ -1701,6 +1701,70 @@ mod tests {
         let body = response.json::<serde_json::Value>();
         assert_eq!(body["object"], "response");
         assert_eq!(body["reasoning"]["effort"], "low");
+    }
+
+    #[tokio::test]
+    async fn create_response_route_accepts_supported_include_values() {
+        let (server, _) = make_server(vec![vec![request_output("done", true)]]);
+
+        let response = server
+            .post("/v1/responses")
+            .json(&serde_json::json!({
+                "model": "test",
+                "input": "Hello",
+                "include": [
+                    "message.output_text.logprobs",
+                    "reasoning.encrypted_content"
+                ]
+            }))
+            .await;
+
+        response.assert_status_ok();
+    }
+
+    #[tokio::test]
+    async fn create_response_route_accepts_input_image_parts() {
+        let (server, engine) = make_server(vec![vec![request_output("done", true)]]);
+
+        let response = server
+            .post("/v1/responses")
+            .json(&serde_json::json!({
+                "model": "test",
+                "input": [{
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "input_text",
+                            "text": "Look at "
+                        },
+                        {
+                            "type": "input_image",
+                            "image_url": "https://example.com/cat.png",
+                            "detail": "low"
+                        }
+                    ]
+                }],
+                "store": true
+            }))
+            .await;
+
+        response.assert_status_ok();
+        let body = response.json::<serde_json::Value>();
+        let response_id = body["id"].as_str().unwrap();
+
+        let items = server
+            .get(&format!("/v1/responses/{response_id}/input_items"))
+            .await;
+        items.assert_status_ok();
+        let items = items.json::<serde_json::Value>();
+        assert_eq!(items["data"][0]["content"][1]["type"], "input_image");
+        assert_eq!(
+            items["data"][0]["content"][1]["image_url"],
+            "https://example.com/cat.png"
+        );
+
+        let prompts = engine.prompts();
+        assert!(prompts[0].contains("[input_image url=https://example.com/cat.png detail=low]"));
     }
 
     #[tokio::test]

--- a/crates/rvllm-api/src/types/responses.rs
+++ b/crates/rvllm-api/src/types/responses.rs
@@ -209,16 +209,61 @@ pub struct CreateResponseRequest {
 /// A text input part inside a message item.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
 pub struct ResponseInputTextPart {
-    #[serde(rename = "type")]
-    pub part_type: String,
     pub text: String,
 }
 
 impl ResponseInputTextPart {
     pub fn new(text: impl Into<String>) -> Self {
+        Self { text: text.into() }
+    }
+}
+
+/// An image input part inside a message item.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
+pub struct ResponseInputImagePart {
+    pub image_url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+impl ResponseInputImagePart {
+    pub fn new(image_url: impl Into<String>, detail: Option<String>) -> Self {
         Self {
-            part_type: "input_text".to_string(),
-            text: text.into(),
+            image_url: image_url.into(),
+            detail,
+        }
+    }
+}
+
+/// A normalized content part inside a message item.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
+#[serde(tag = "type")]
+pub enum ResponseInputContentPart {
+    #[serde(rename = "input_text")]
+    InputText(ResponseInputTextPart),
+    #[serde(rename = "input_image")]
+    InputImage(ResponseInputImagePart),
+}
+
+impl ResponseInputContentPart {
+    pub fn input_text(text: impl Into<String>) -> Self {
+        Self::InputText(ResponseInputTextPart::new(text))
+    }
+
+    pub fn input_image(image_url: impl Into<String>, detail: Option<String>) -> Self {
+        Self::InputImage(ResponseInputImagePart::new(image_url, detail))
+    }
+
+    fn to_prompt_text(&self) -> String {
+        match self {
+            Self::InputText(part) => part.text.clone(),
+            Self::InputImage(part) => match part.detail.as_deref() {
+                Some(detail) => format!(
+                    "[input_image url={} detail={}]",
+                    part.image_url, detail
+                ),
+                None => format!("[input_image url={}]", part.image_url),
+            },
         }
     }
 }
@@ -227,11 +272,11 @@ impl ResponseInputTextPart {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
 pub struct ResponseInputMessage {
     pub role: String,
-    pub content: Vec<ResponseInputTextPart>,
+    pub content: Vec<ResponseInputContentPart>,
 }
 
 impl ResponseInputMessage {
-    pub fn new(role: impl Into<String>, content: Vec<ResponseInputTextPart>) -> Self {
+    pub fn new(role: impl Into<String>, content: Vec<ResponseInputContentPart>) -> Self {
         Self {
             role: role.into(),
             content,
@@ -241,7 +286,12 @@ impl ResponseInputMessage {
     pub fn to_chat_message(&self) -> ChatMessage {
         ChatMessage {
             role: self.role.clone(),
-            content: self.content.iter().map(|part| part.text.as_str()).collect(),
+            content: self
+                .content
+                .iter()
+                .map(ResponseInputContentPart::to_prompt_text)
+                .collect::<Vec<_>>()
+                .join(""),
         }
     }
 }
@@ -641,11 +691,7 @@ impl CreateResponseRequest {
                 "conversation state objects are not supported on /v1/responses yet".into(),
             ));
         }
-        if self.include.is_some() {
-            return Err(ApiError::InvalidRequest(
-                "include options are not supported on /v1/responses yet".into(),
-            ));
-        }
+        let _ = self.normalize_include()?;
         if let Some(truncation) = &self.truncation {
             if truncation != "disabled" {
                 return Err(ApiError::InvalidRequest(
@@ -842,6 +888,36 @@ impl CreateResponseRequest {
         Ok(normalized)
     }
 
+    pub fn normalize_include(&self) -> Result<Vec<String>, ApiError> {
+        const SUPPORTED_INCLUDES: &[&str] = &[
+            "code_interpreter_call.outputs",
+            "computer_call_output.output.image_url",
+            "file_search_call.results",
+            "message.input_image.image_url",
+            "message.output_text.logprobs",
+            "reasoning.encrypted_content",
+            "web_search_call.action.sources",
+        ];
+
+        let Some(include) = &self.include else {
+            return Ok(Vec::new());
+        };
+
+        include
+            .iter()
+            .map(|value| {
+                if SUPPORTED_INCLUDES.contains(&value.as_str()) {
+                    Ok(value.clone())
+                } else {
+                    Err(ApiError::InvalidRequest(format!(
+                        "responses include value '{}' is not supported yet",
+                        value
+                    )))
+                }
+            })
+            .collect()
+    }
+
     pub fn normalize_input_items(&self) -> Result<Vec<ResponseInputItem>, ApiError> {
         match &self.input {
             None => Ok(Vec::new()),
@@ -851,7 +927,7 @@ impl CreateResponseRequest {
                 }
                 Ok(vec![ResponseInputItem::Message(ResponseInputMessage::new(
                     "user",
-                    vec![ResponseInputTextPart::new(text.clone())],
+                    vec![ResponseInputContentPart::input_text(text.clone())],
                 ))])
             }
             Some(ResponseInput::Items(items)) => {
@@ -944,7 +1020,7 @@ fn normalize_function_call_output_item(
 
 fn normalize_input_parts(
     value: &serde_json::Value,
-) -> Result<Vec<ResponseInputTextPart>, ApiError> {
+) -> Result<Vec<ResponseInputContentPart>, ApiError> {
     match value {
         serde_json::Value::String(text) => {
             if text.is_empty() {
@@ -952,7 +1028,7 @@ fn normalize_input_parts(
                     "responses input text must not be empty".into(),
                 ));
             }
-            Ok(vec![ResponseInputTextPart::new(text.clone())])
+            Ok(vec![ResponseInputContentPart::input_text(text.clone())])
         }
         serde_json::Value::Array(parts) => {
             if parts.is_empty() {
@@ -974,24 +1050,51 @@ fn normalize_input_parts(
                             "responses input content parts require a type".into(),
                         ));
                     };
-                    if part_type != "input_text" {
-                        return Err(ApiError::InvalidRequest(format!(
+                    match part_type {
+                        "input_text" => {
+                            let text = part_map
+                                .get("text")
+                                .and_then(serde_json::Value::as_str)
+                                .ok_or_else(|| {
+                                    ApiError::InvalidRequest(
+                                        "input_text parts require a text field".into(),
+                                    )
+                                })?;
+                            if text.is_empty() {
+                                return Err(ApiError::InvalidRequest(
+                                    "responses input text must not be empty".into(),
+                                ));
+                            }
+                            Ok(ResponseInputContentPart::input_text(text.to_string()))
+                        }
+                        "input_image" => {
+                            let image_url = part_map
+                                .get("image_url")
+                                .and_then(serde_json::Value::as_str)
+                                .ok_or_else(|| {
+                                    ApiError::InvalidRequest(
+                                        "input_image parts require an image_url field".into(),
+                                    )
+                                })?;
+                            if image_url.is_empty() {
+                                return Err(ApiError::InvalidRequest(
+                                    "responses input image_url must not be empty".into(),
+                                ));
+                            }
+                            let detail = part_map
+                                .get("detail")
+                                .and_then(serde_json::Value::as_str)
+                                .map(str::to_string);
+                            Ok(ResponseInputContentPart::input_image(
+                                image_url.to_string(),
+                                detail,
+                            ))
+                        }
+                        _ => Err(ApiError::InvalidRequest(format!(
                             "responses input content part type '{}' is not supported yet",
                             part_type
-                        )));
+                        ))),
                     }
-                    let text = part_map
-                        .get("text")
-                        .and_then(serde_json::Value::as_str)
-                        .ok_or_else(|| {
-                            ApiError::InvalidRequest("input_text parts require a text field".into())
-                        })?;
-                    if text.is_empty() {
-                        return Err(ApiError::InvalidRequest(
-                            "responses input text must not be empty".into(),
-                        ));
-                    }
-                    Ok(ResponseInputTextPart::new(text.to_string()))
                 })
                 .collect()
         }
@@ -1040,7 +1143,7 @@ mod tests {
             input,
             vec![ResponseInputItem::Message(ResponseInputMessage::new(
                 "user",
-                vec![ResponseInputTextPart::new("Hello")]
+                vec![ResponseInputContentPart::input_text("Hello")]
             ))]
         );
     }
@@ -1124,14 +1227,105 @@ mod tests {
     }
 
     #[test]
-    fn rejects_multimodal_parts() {
-        let err = normalize_input_parts(&serde_json::json!([
-            {"type": "input_image", "image_url": "https://example.com/image.png"}
+    fn accepts_input_image_parts() {
+        let parts = normalize_input_parts(&serde_json::json!([
+            {
+                "type": "input_image",
+                "image_url": "https://example.com/image.png",
+                "detail": "low"
+            }
         ]))
-        .unwrap_err();
+        .unwrap();
+        assert_eq!(
+            parts,
+            vec![ResponseInputContentPart::input_image(
+                "https://example.com/image.png",
+                Some("low".into())
+            )]
+        );
+    }
+
+    #[test]
+    fn image_parts_render_to_prompt_marker() {
+        let message = ResponseInputMessage::new(
+            "user",
+            vec![
+                ResponseInputContentPart::input_text("Look at "),
+                ResponseInputContentPart::input_image(
+                    "https://example.com/image.png",
+                    Some("high".into()),
+                ),
+            ],
+        );
+        assert_eq!(
+            message.to_chat_message().content,
+            "Look at [input_image url=https://example.com/image.png detail=high]"
+        );
+    }
+
+    #[test]
+    fn request_accepts_supported_include_values() {
+        let req = CreateResponseRequest {
+            model: "test".into(),
+            input: Some(ResponseInput::Text("Hello".into())),
+            instructions: None,
+            max_output_tokens: None,
+            temperature: 1.0,
+            top_p: 1.0,
+            stream: false,
+            store: true,
+            previous_response_id: None,
+            metadata: BTreeMap::new(),
+            background: None,
+            tools: None,
+            tool_choice: None,
+            parallel_tool_calls: true,
+            text: None,
+            reasoning: None,
+            conversation: None,
+            include: Some(vec![
+                "message.input_image.image_url".into(),
+                "reasoning.encrypted_content".into(),
+            ]),
+            truncation: None,
+        };
+        req.validate().unwrap();
+        assert_eq!(
+            req.normalize_include().unwrap(),
+            vec![
+                "message.input_image.image_url".to_string(),
+                "reasoning.encrypted_content".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn request_rejects_unknown_include_values() {
+        let req = CreateResponseRequest {
+            model: "test".into(),
+            input: Some(ResponseInput::Text("Hello".into())),
+            instructions: None,
+            max_output_tokens: None,
+            temperature: 1.0,
+            top_p: 1.0,
+            stream: false,
+            store: true,
+            previous_response_id: None,
+            metadata: BTreeMap::new(),
+            background: None,
+            tools: None,
+            tool_choice: None,
+            parallel_tool_calls: true,
+            text: None,
+            reasoning: None,
+            conversation: None,
+            include: Some(vec!["message.output_text.foo".into()]),
+            truncation: None,
+        };
+        let err = req.validate().unwrap_err();
         assert!(err
             .to_string()
-            .contains("responses input content part type 'input_image' is not supported yet"));
+            .contains("responses include value 'message.output_text.foo' is not supported yet"));
     }
 
     #[test]

--- a/tests/api_compat/test_openai_client.py
+++ b/tests/api_compat/test_openai_client.py
@@ -294,6 +294,44 @@ class TestResponses:
         data = r.json()
         assert data["reasoning"]["effort"] == "low"
 
+    def test_response_accepts_include_values(self):
+        """Responses accept documented include values without a validation error"""
+        r = requests.post(f"{BASE_URL}/v1/responses", json={
+            "model": "test",
+            "input": "Hello",
+            "include": [
+                "message.output_text.logprobs",
+                "reasoning.encrypted_content",
+            ],
+        })
+        assert r.status_code == 200
+
+    def test_response_accepts_input_image_parts(self):
+        """Responses accept input_image parts and preserve them in stored input items"""
+        r = requests.post(f"{BASE_URL}/v1/responses", json={
+            "model": "test",
+            "input": [{
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "Look at "},
+                    {
+                        "type": "input_image",
+                        "image_url": "https://example.com/cat.png",
+                        "detail": "low",
+                    },
+                ],
+            }],
+            "store": True,
+        })
+        assert r.status_code == 200
+        response_id = r.json()["id"]
+
+        items = requests.get(f"{BASE_URL}/v1/responses/{response_id}/input_items")
+        assert items.status_code == 200
+        data = items.json()
+        assert data["data"][0]["content"][1]["type"] == "input_image"
+        assert data["data"][0]["content"][1]["image_url"] == "https://example.com/cat.png"
+
     def test_response_rejects_built_in_tools(self):
         """Built-in Responses tools are still rejected explicitly"""
         r = requests.post(f"{BASE_URL}/v1/responses", json={


### PR DESCRIPTION
## Summary
- add structured `text.format` support for `/v1/responses`
- add background stored-response jobs for `/v1/responses`
- add initial `reasoning.effort` support for `/v1/responses`
- accept documented `include` values on `/v1/responses`
- accept and persist `input_image` parts for `/v1/responses`

## Included in this PR
- `text.format` -> guided decoding plumbing for `json_object` and `json_schema`
- response objects preserve the requested text format
- `background=true` support for stored Responses jobs
- immediate `in_progress` response creation with async completion and stored retrieval
- validation guardrails for unsupported combinations like `background=true` with `stream=true`
- `reasoning.effort` request support with echoed response metadata
- documented `include` values no longer fail validation outright
- `input_image` parts are parsed and preserved in stored input items

## Tracking
- Closes #14
- Closes #15
- Closes #16
- Closes #17
- Closes #18

## Validation
- `cargo test -p rvllm-api responses --lib`
- `cargo test -p rvllm-api --lib`
- `python3 -m py_compile tests/api_compat/test_openai_client.py`

## Notes
- The `input_image` work in this PR is request-shape compatibility and stored-item preservation on the current text-only runtime. It is not native multimodal inference yet.
- Deferred follow-ups are tracked separately:
  - #20 native multimodal runtime support
  - #21 populate include payloads instead of only accepting include values
  - #22 broader reasoning support beyond `effort`
  - #23 conversation state objects on `/v1/responses`
- Self-assignment is currently blocked by repo permissions for `gracee3`.