### PR TITLE
Harden CUDA graph replay padding and eligibility

### DIFF
--- a/crates/rvllm-model-runner/src/gpu_runner.rs
+++ b/crates/rvllm-model-runner/src/gpu_runner.rs
@@ -1523,7 +1523,9 @@ mod cuda_impl {
         }
 
         /// Upload metadata padded to `padded_batch` tokens.
-        /// Extra slots are filled with dummy data (duplicating seq 0's metadata).
+        ///
+        /// Extra slots use safe decode sentinels so graph-captured kernels skip
+        /// padded entries instead of touching live KV slots.
         pub fn upload_metadata_padded(
             &self,
             token_ids: &[u32],
@@ -1545,24 +1547,18 @@ mod cuda_impl {
             let mut padded_positions: Vec<u32> = positions.to_vec();
             padded_positions.resize(padded_batch, 0);
 
-            // Pad attention metadata
+            // Pad attention metadata using the same sentinels as GraphRunner:
+            // slot_mapping=-1 skips cache writes and context_len=0 marks the
+            // sequence as empty for attention kernels.
             let mut padded_meta = attn_meta.clone();
-            let dummy_ctx = if attn_meta.context_lens.is_empty() {
-                1
-            } else {
-                attn_meta.context_lens[0]
-            };
-            padded_meta.context_lens.resize(padded_batch, dummy_ctx);
+            padded_meta.context_lens.resize(padded_batch, 0);
             padded_meta.query_lens.resize(padded_batch, 1);
-            let dummy_bt = if attn_meta.block_tables.is_empty() {
-                vec![]
-            } else {
-                attn_meta.block_tables[0].clone()
-            };
             for _ in 0..pad_count {
-                padded_meta.block_tables.push(dummy_bt.clone());
+                padded_meta.block_tables.push(vec![0]);
             }
-            padded_meta.slot_mapping.resize(padded_batch, 0);
+            padded_meta.slot_mapping.resize(padded_batch, u32::MAX);
+            padded_meta.max_context_len =
+                padded_meta.context_lens.iter().copied().max().unwrap_or(0);
 
             self.upload_metadata(&padded_tokens, &padded_positions, &padded_meta)
         }

--- a/crates/rvllm-worker/src/gpu_worker.rs
+++ b/crates/rvllm-worker/src/gpu_worker.rs
@@ -1632,17 +1632,12 @@ impl GpuWorker {
             self.fp8_pre_forward_dequantize(model_input)?;
         }
 
-        // Use graphs for any pure decode step (all query_lens == 1).
-        // Sampling params don't matter -- graphs capture the forward pass
-        // (GEMMs, attention, norms), not the sampling/logit processing.
-        let is_decode = !model_input.is_prefill
-            && model_input
-                .attention_metadata
-                .query_lens
-                .iter()
-                .all(|&q| q == 1);
+        // Graph replay currently captures the GPU-only argmax path, so it is
+        // only valid for greedy decode steps within the configured graph range.
+        // Non-greedy sampling still needs full logits from the raw path.
+        let can_graph = greedy_only && self.graph_runner.can_use_graph(model_input);
 
-        let result = if !is_decode || !self.graph_runner.is_enabled() {
+        let result = if !can_graph || !self.graph_runner.is_enabled() {
             self.raw_gpu_forward_ex(model_input, greedy_only)
         } else {
             #[cfg(feature = "cuda")]
@@ -1714,21 +1709,18 @@ impl GpuWorker {
             .as_ref()
             .ok_or_else(|| LLMError::GpuError("GPU model runner not initialized".into()))?;
 
-        // Upload metadata (skip clone when no padding needed)
-        if actual_batch == padded_batch {
-            runner.upload_metadata(
-                &model_input.token_ids,
-                &model_input.position_ids,
-                &model_input.attention_metadata,
-            )?;
-        } else {
-            runner.upload_metadata_padded(
-                &model_input.token_ids,
-                &model_input.position_ids,
-                &model_input.attention_metadata,
-                padded_batch,
-            )?;
-        }
+        let (padded_input, padded_actual_batch) = self.graph_runner.pad_input(model_input)?;
+        debug_assert_eq!(padded_actual_batch, actual_batch);
+        debug_assert_eq!(padded_input.num_tokens(), padded_batch);
+
+        // Upload metadata using the safe padded decode input. Padded tokens use
+        // slot_mapping=-1 and context_len=0 so cache-write/attention kernels
+        // skip them instead of corrupting live KV slots.
+        runner.upload_metadata(
+            &padded_input.token_ids,
+            &padded_input.position_ids,
+            &padded_input.attention_metadata,
+        )?;
 
         let graph = self
             .graph_runner
@@ -1749,7 +1741,7 @@ impl GpuWorker {
         let dst = pinned
             .as_mut_slice()
             .map_err(|e| LLMError::GpuError(format!("pinned buf write: {e}")))?;
-        runner.read_graph_output_async(actual_batch, dst)?;
+        runner.read_graph_output_async(padded_actual_batch, dst)?;
         Ok(ForwardOutput::TokenIdsPending { actual_batch })
     }
 
@@ -1762,7 +1754,6 @@ impl GpuWorker {
         padded_batch: usize,
         _greedy_only: bool,
     ) -> Result<ForwardOutput> {
-        let max_context_len = model_input.attention_metadata.max_context_len;
         self.ensure_pinned_output_capacity(actual_batch)?;
 
         let runner = self
@@ -1781,14 +1772,22 @@ impl GpuWorker {
             actual_batch, "capturing CUDA graph for padded batch size"
         );
 
+        let (padded_input, padded_actual_batch) = self.graph_runner.pad_input(model_input)?;
+        debug_assert_eq!(padded_actual_batch, actual_batch);
+        debug_assert_eq!(padded_input.num_tokens(), padded_batch);
+
         // Warmup forward (outside capture)
-        runner.upload_metadata_padded(
-            &model_input.token_ids,
-            &model_input.position_ids,
-            &model_input.attention_metadata,
-            padded_batch,
+        runner.upload_metadata(
+            &padded_input.token_ids,
+            &padded_input.position_ids,
+            &padded_input.attention_metadata,
         )?;
-        runner.forward_gpu_only(padded_batch, padded_batch, max_context_len, false)?;
+        runner.forward_gpu_only(
+            padded_batch,
+            padded_batch,
+            padded_input.attention_metadata.max_context_len,
+            false,
+        )?;
 
         // Sync before capture
         let cuda_stream = runner.cuda_stream().clone();
@@ -1797,11 +1796,10 @@ impl GpuWorker {
             .map_err(|e| LLMError::GpuError(format!("pre-capture sync: {e}")))?;
 
         // Re-upload padded metadata
-        runner.upload_metadata_padded(
-            &model_input.token_ids,
-            &model_input.position_ids,
-            &model_input.attention_metadata,
-            padded_batch,
+        runner.upload_metadata(
+            &padded_input.token_ids,
+            &padded_input.position_ids,
+            &padded_input.attention_metadata,
         )?;
 
         // Capture
@@ -1812,8 +1810,12 @@ impl GpuWorker {
             return Err(LLMError::GpuError(format!("graph capture failed: {e}")));
         }
 
-        let fwd_result =
-            runner.forward_gpu_only(padded_batch, padded_batch, max_context_len, false);
+        let fwd_result = runner.forward_gpu_only(
+            padded_batch,
+            padded_batch,
+            padded_input.attention_metadata.max_context_len,
+            false,
+        );
 
         match fwd_result {
             Ok(()) => {
@@ -1830,7 +1832,7 @@ impl GpuWorker {
                 let dst = pinned
                     .as_mut_slice()
                     .map_err(|e| LLMError::GpuError(format!("pinned buf write: {e}")))?;
-                runner.read_graph_output_async(actual_batch, dst)?;
+                runner.read_graph_output_async(padded_actual_batch, dst)?;
                 Ok(ForwardOutput::TokenIdsPending { actual_batch })
             }
             Err(e) => {

--- a/crates/rvllm-worker/src/graph_runner.rs
+++ b/crates/rvllm-worker/src/graph_runner.rs
@@ -76,8 +76,8 @@ impl GraphRunner {
         if !self.config.enabled || !self.pool.is_enabled() {
             return false;
         }
-        // Only decode steps (not prefill)
-        if input.is_prefill {
+        // Only single-token decode steps are graphable.
+        if input.is_prefill || input.attention_metadata.query_lens.iter().any(|&q| q != 1) {
             return false;
         }
         let batch_size = input.num_tokens();
@@ -334,6 +334,15 @@ mod tests {
     }
 
     #[test]
+    fn can_use_graph_rejects_multi_token_decode_shapes() {
+        let runner = GraphRunner::new(GraphRunnerConfig::default());
+        let mut decode = make_decode_input(4);
+        decode.attention_metadata.query_lens[0] = 2;
+
+        assert!(!runner.can_use_graph(&decode));
+    }
+
+    #[test]
     fn can_use_graph_disabled() {
         let mut runner = GraphRunner::new(GraphRunnerConfig::default());
         runner.disable();
@@ -363,6 +372,19 @@ mod tests {
         assert_eq!(padded.num_tokens(), 4); // rounded up to 4
         assert_eq!(padded.token_ids[..3], vec![42, 42, 42]);
         assert_eq!(padded.token_ids[3], 0); // padding token
+    }
+
+    #[test]
+    fn pad_input_uses_skip_sentinels_for_padding() {
+        let runner = GraphRunner::new(GraphRunnerConfig::default());
+        let input = make_decode_input(3);
+        let (padded, _) = runner.pad_input(&input).unwrap();
+
+        assert_eq!(padded.attention_metadata.slot_mapping[3], u32::MAX);
+        assert_eq!(padded.attention_metadata.context_lens[3], 0);
+        assert_eq!(padded.attention_metadata.query_lens[3], 1);
+        assert_eq!(padded.attention_metadata.block_tables[3], vec![0]);
+        assert_eq!(padded.position_ids[3], 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

  This hardens CUDA graph replay correctness in the decode path.

  - restrict graph replay to greedy single-token decode shapes
  - replace padded graph metadata that reused live KV slot 0 with safe sentinels
  - add regression tests for graph eligibility and padded metadata semantics

  ## Why

  The graphed path currently returns token IDs from the GPU argmax path, so non-greedy sampling should
  not enter it.

  Also, padded graph batches were reusing live metadata for padded entries, including KV slot 0. This
  patch switches padded graph metadata to safe decode sentinels so replayed kernels skip padded
  entries instead of touching live KV state.

  ## Validation

  - `cargo test --offline -p rvllm-worker graph_runner -- --nocapture`
  - `cargo test --offline -p rvllm-worker --features cuda --no-run`