### PR TITLE
fix: use config rope_theta in CPU reference path + add RVLLM_NO_GRAPH

### DIFF
--- a/crates/rvllm-model-runner/src/architectures/cohere.rs
+++ b/crates/rvllm-model-runner/src/architectures/cohere.rs
@@ -28,6 +28,7 @@ pub struct CohereForCausalLM {
     head_dim: usize,
     vocab_size: usize,
     layernorm_eps: f32,
+    rope_theta: f32,
     embed_tokens: GpuBuffer<f16>,
     layers: Vec<CohereLayer>,
     norm_weight: GpuBuffer<f16>,
@@ -170,7 +171,8 @@ impl CohereForCausalLM {
             num_kv_heads,
             head_dim,
             vocab_size: config.vocab_size,
-            layernorm_eps: 1e-5,
+            layernorm_eps: config.rms_norm_eps,
+            rope_theta: config.rope_theta,
             embed_tokens,
             layers,
             norm_weight,
@@ -229,7 +231,7 @@ impl Architecture for CohereForCausalLM {
 
             // RoPE on normalized Q/K.
             let (q_rot, k_rot) =
-                RotaryEmbedding::forward(&input.position_ids, &q_normed, &k_normed, self.head_dim)?;
+                RotaryEmbedding::forward_with_base(&input.position_ids, &q_normed, &k_normed, self.head_dim, self.rope_theta)?;
 
             // Expand shared keys for MQA: replicate the single KV head(s) to match num_heads.
             let k_expanded = expand_kv_heads(

--- a/crates/rvllm-model-runner/src/architectures/deepseek.rs
+++ b/crates/rvllm-model-runner/src/architectures/deepseek.rs
@@ -32,6 +32,7 @@ struct DeepSeekConfig {
     vocab_size: usize,
     intermediate_size: usize,
     rms_norm_eps: f32,
+    rope_theta: f32,
     /// Latent dimension for MLA KV compression.
     kv_lora_rank: usize,
     /// Dimension for RoPE portion of queries in MLA.
@@ -115,7 +116,8 @@ impl DeepSeekV2ForCausalLM {
             head_dim: config.head_dim,
             vocab_size: config.vocab_size,
             intermediate_size: config.intermediate_size,
-            rms_norm_eps: 1e-6,
+            rms_norm_eps: config.rms_norm_eps,
+            rope_theta: config.rope_theta,
             kv_lora_rank,
             qk_rope_head_dim,
             qk_nope_head_dim,
@@ -322,7 +324,7 @@ impl DeepSeekV2ForCausalLM {
 
         // RoPE on Q and K.
         let (q_rot, k_rot) =
-            RotaryEmbedding::forward(&input.position_ids, &q, &k, self.config.head_dim)?;
+            RotaryEmbedding::forward_with_base(&input.position_ids, &q, &k, self.config.head_dim, self.config.rope_theta)?;
 
         // Attention.
         let attn_out =

--- a/crates/rvllm-model-runner/src/architectures/embedding.rs
+++ b/crates/rvllm-model-runner/src/architectures/embedding.rs
@@ -53,6 +53,7 @@ pub struct EmbeddingModel {
     #[allow(dead_code)]
     num_kv_heads: usize,
     norm_eps: f32,
+    rope_theta: f32,
     pooling: PoolingMode,
     normalize: bool,
     embed_tokens: GpuBuffer<f16>,
@@ -157,7 +158,8 @@ impl EmbeddingModel {
             head_dim,
             num_heads,
             num_kv_heads,
-            norm_eps: 1e-5,
+            norm_eps: config.rms_norm_eps,
+            rope_theta: config.rope_theta,
             pooling,
             normalize: true,
             embed_tokens,
@@ -388,7 +390,7 @@ impl Architecture for EmbeddingModel {
 
             // RoPE (no-op for BERT, but applied for E5-mistral-style models).
             let (q_rot, k_rot) = if !self.use_layer_norm {
-                RotaryEmbedding::forward(&input.position_ids, &q, &k, self.head_dim)?
+                RotaryEmbedding::forward_with_base(&input.position_ids, &q, &k, self.head_dim, self.rope_theta)?
             } else {
                 (q, k)
             };

--- a/crates/rvllm-model-runner/src/architectures/gemma.rs
+++ b/crates/rvllm-model-runner/src/architectures/gemma.rs
@@ -178,6 +178,7 @@ pub struct GemmaForCausalLM {
     head_dim: usize,
     vocab_size: usize,
     rms_norm_eps: f32,
+    rope_theta: f32,
     embed_tokens: GpuBuffer<f16>,
     layers: Vec<GemmaLayer>,
     norm_weight: GpuBuffer<f16>,
@@ -269,7 +270,8 @@ impl GemmaForCausalLM {
             hidden_size: config.hidden_size,
             head_dim: config.head_dim,
             vocab_size: config.vocab_size,
-            rms_norm_eps: 1e-6,
+            rms_norm_eps: config.rms_norm_eps,
+            rope_theta: config.rope_theta,
             embed_tokens,
             layers,
             norm_weight,
@@ -301,7 +303,7 @@ impl Architecture for GemmaForCausalLM {
             let v = LinearLayer::forward(&normed, &layer.v_proj, None)?;
 
             let (q_rot, k_rot) =
-                RotaryEmbedding::forward(&input.position_ids, &q, &k, self.head_dim)?;
+                RotaryEmbedding::forward_with_base(&input.position_ids, &q, &k, self.head_dim, self.rope_theta)?;
 
             let attn_out =
                 attention.forward(&q_rot, &k_rot, &v, &input.attention_metadata, layer_idx)?;
@@ -341,6 +343,7 @@ pub struct Gemma2ForCausalLM {
     head_dim: usize,
     vocab_size: usize,
     rms_norm_eps: f32,
+    rope_theta: f32,
     /// Soft cap applied as cap * tanh(logits / cap). 0.0 means disabled.
     attn_logit_softcap: f32,
     /// Final logit soft-cap before sampling. 0.0 means disabled.
@@ -450,7 +453,8 @@ impl Gemma2ForCausalLM {
             hidden_size: config.hidden_size,
             head_dim: config.head_dim,
             vocab_size: config.vocab_size,
-            rms_norm_eps: 1e-6,
+            rms_norm_eps: config.rms_norm_eps,
+            rope_theta: config.rope_theta,
             attn_logit_softcap: 50.0,
             final_logit_softcap: 30.0,
             sliding_window: 4096,
@@ -484,7 +488,7 @@ impl Architecture for Gemma2ForCausalLM {
             let v = LinearLayer::forward(&normed, &layer.v_proj, None)?;
 
             let (q_rot, k_rot) =
-                RotaryEmbedding::forward(&input.position_ids, &q, &k, self.head_dim)?;
+                RotaryEmbedding::forward_with_base(&input.position_ids, &q, &k, self.head_dim, self.rope_theta)?;
 
             // Attention (sliding window on even layers, global on odd).
             let _use_sliding = self.sliding_window > 0 && layer_idx % 2 == 0;

--- a/crates/rvllm-model-runner/src/architectures/gpt_neox.rs
+++ b/crates/rvllm-model-runner/src/architectures/gpt_neox.rs
@@ -33,6 +33,7 @@ struct NeoXConfig {
     intermediate_size: usize,
     vocab_size: usize,
     layer_norm_eps: f32,
+    rope_theta: f32,
     use_parallel_residual: bool,
 }
 
@@ -85,7 +86,8 @@ impl GPTNeoXForCausalLM {
             head_dim: config.head_dim,
             intermediate_size: config.intermediate_size,
             vocab_size: config.vocab_size,
-            layer_norm_eps: 1e-5,
+            layer_norm_eps: config.rms_norm_eps,
+            rope_theta: config.rope_theta,
             use_parallel_residual: true,
         };
 
@@ -215,7 +217,7 @@ impl Architecture for GPTNeoXForCausalLM {
             // RoPE on full head_dim (non-interleaved -- same RotaryEmbedding,
             // GPT-NeoX applies rotation to the entire head dimension).
             let (q_rot, k_rot) =
-                RotaryEmbedding::forward(&input.position_ids, &q, &k, self.config.head_dim)?;
+                RotaryEmbedding::forward_with_base(&input.position_ids, &q, &k, self.config.head_dim, self.config.rope_theta)?;
 
             // Attention.
             let attn_out =
@@ -303,7 +305,8 @@ impl StableLmForCausalLM {
             head_dim: config.head_dim,
             intermediate_size: config.intermediate_size,
             vocab_size: config.vocab_size,
-            layer_norm_eps: 1e-5,
+            layer_norm_eps: config.rms_norm_eps,
+            rope_theta: config.rope_theta,
             use_parallel_residual: true,
         };
 
@@ -427,7 +430,7 @@ impl Architecture for StableLmForCausalLM {
             let v = LinearLayer::forward(&normed_attn, &layer.v_proj, layer.v_bias.as_ref())?;
 
             let (q_rot, k_rot) =
-                RotaryEmbedding::forward(&input.position_ids, &q, &k, self.config.head_dim)?;
+                RotaryEmbedding::forward_with_base(&input.position_ids, &q, &k, self.config.head_dim, self.config.rope_theta)?;
 
             let attn_out =
                 attention.forward(&q_rot, &k_rot, &v, &input.attention_metadata, layer_idx)?;

--- a/crates/rvllm-model-runner/src/architectures/llama.rs
+++ b/crates/rvllm-model-runner/src/architectures/llama.rs
@@ -30,6 +30,7 @@ struct LlamaConfig {
     head_dim: usize,
     vocab_size: usize,
     rms_norm_eps: f32,
+    rope_theta: f32,
 }
 
 struct LlamaLayer {
@@ -53,7 +54,8 @@ impl LlamaForCausalLM {
             num_kv_heads: config.num_kv_heads,
             head_dim: config.head_dim,
             vocab_size: config.vocab_size,
-            rms_norm_eps: 1e-5,
+            rms_norm_eps: config.rms_norm_eps,
+            rope_theta: config.rope_theta,
         };
 
         let embed_tokens = weights
@@ -157,8 +159,9 @@ impl Architecture for LlamaForCausalLM {
             let v = LinearLayer::forward(&normed, &layer.v_proj, None)?;
 
             // RoPE.
-            let (q_rot, k_rot) =
-                RotaryEmbedding::forward(&input.position_ids, &q, &k, self.config.head_dim)?;
+            let (q_rot, k_rot) = RotaryEmbedding::forward_with_base(
+                &input.position_ids, &q, &k, self.config.head_dim, self.config.rope_theta,
+            )?;
 
             // Attention.
             let attn_out =

--- a/crates/rvllm-model-runner/src/architectures/mistral.rs
+++ b/crates/rvllm-model-runner/src/architectures/mistral.rs
@@ -23,6 +23,7 @@ pub struct MistralForCausalLM {
     head_dim: usize,
     vocab_size: usize,
     rms_norm_eps: f32,
+    rope_theta: f32,
     embed_tokens: GpuBuffer<f16>,
     layers: Vec<MistralLayer>,
     norm_weight: GpuBuffer<f16>,
@@ -111,7 +112,8 @@ impl MistralForCausalLM {
             hidden_size: config.hidden_size,
             head_dim: config.head_dim,
             vocab_size: config.vocab_size,
-            rms_norm_eps: 1e-5,
+            rms_norm_eps: config.rms_norm_eps,
+            rope_theta: config.rope_theta,
             embed_tokens,
             layers,
             norm_weight,
@@ -140,7 +142,7 @@ impl Architecture for MistralForCausalLM {
             let v = LinearLayer::forward(&normed, &layer.v_proj, None)?;
 
             let (q_rot, k_rot) =
-                RotaryEmbedding::forward(&input.position_ids, &q, &k, self.head_dim)?;
+                RotaryEmbedding::forward_with_base(&input.position_ids, &q, &k, self.head_dim, self.rope_theta)?;
 
             let attn_out =
                 attention.forward(&q_rot, &k_rot, &v, &input.attention_metadata, layer_idx)?;

--- a/crates/rvllm-model-runner/src/architectures/mixtral.rs
+++ b/crates/rvllm-model-runner/src/architectures/mixtral.rs
@@ -42,6 +42,7 @@ pub struct MixtralForCausalLM {
     head_dim: usize,
     vocab_size: usize,
     rms_norm_eps: f32,
+    rope_theta: f32,
     embed_tokens: GpuBuffer<f16>,
     layers: Vec<MixtralLayer>,
     norm_weight: GpuBuffer<f16>,
@@ -148,7 +149,8 @@ impl MixtralForCausalLM {
             hidden_size: config.hidden_size,
             head_dim: config.head_dim,
             vocab_size: config.vocab_size,
-            rms_norm_eps: 1e-5,
+            rms_norm_eps: config.rms_norm_eps,
+            rope_theta: config.rope_theta,
             embed_tokens,
             layers,
             norm_weight,
@@ -180,7 +182,7 @@ impl Architecture for MixtralForCausalLM {
 
             // RoPE.
             let (q_rot, k_rot) =
-                RotaryEmbedding::forward(&input.position_ids, &q, &k, self.head_dim)?;
+                RotaryEmbedding::forward_with_base(&input.position_ids, &q, &k, self.head_dim, self.rope_theta)?;
 
             // Attention (sliding window handled by the backend).
             let attn_out =

--- a/crates/rvllm-model-runner/src/architectures/phi.rs
+++ b/crates/rvllm-model-runner/src/architectures/phi.rs
@@ -48,6 +48,8 @@ struct PhiConfig {
     rotary_dim: usize,
     /// Norm epsilon.
     norm_eps: f32,
+    /// RoPE base frequency.
+    rope_theta: f32,
     #[allow(dead_code)]
     variant: PhiVariant,
 }
@@ -143,6 +145,7 @@ impl PhiForCausalLM {
             partial_rotary_factor,
             rotary_dim,
             norm_eps,
+            rope_theta: config.rope_theta,
             variant,
         };
 
@@ -384,6 +387,7 @@ impl PhiForCausalLM {
             &k,
             self.config.head_dim,
             self.config.rotary_dim,
+            self.config.rope_theta,
         )?;
 
         let attn_out =
@@ -431,6 +435,7 @@ impl PhiForCausalLM {
             &k,
             self.config.head_dim,
             self.config.rotary_dim,
+            self.config.rope_theta,
         )?;
 
         let attn_out =
@@ -463,10 +468,11 @@ fn partial_rotary_forward(
     key: &GpuBuffer<f16>,
     head_dim: usize,
     rotary_dim: usize,
+    rope_theta: f32,
 ) -> Result<(GpuBuffer<f16>, GpuBuffer<f16>)> {
     if rotary_dim == head_dim {
         // Full rotation, use standard RoPE.
-        return RotaryEmbedding::forward(positions, query, key, head_dim);
+        return RotaryEmbedding::forward_with_base(positions, query, key, head_dim, rope_theta);
     }
 
     let num_tokens = positions.len();
@@ -503,7 +509,7 @@ fn partial_rotary_forward(
     let q_rot_buf = GpuBuffer::from_vec(q_rot_part, vec![num_tokens, num_q_heads * rotary_dim]);
     let k_rot_buf = GpuBuffer::from_vec(k_rot_part, vec![num_tokens, num_k_heads * rotary_dim]);
     let (q_rotated, k_rotated) =
-        RotaryEmbedding::forward(positions, &q_rot_buf, &k_rot_buf, rotary_dim)?;
+        RotaryEmbedding::forward_with_base(positions, &q_rot_buf, &k_rot_buf, rotary_dim, rope_theta)?;
 
     // Reassemble: interleave rotary and pass-through per head.
     let pass_dim = head_dim - rotary_dim;
@@ -589,7 +595,7 @@ mod tests {
         let vals: Vec<f16> = (1..=8).map(|i| f16::from_f32(i as f32)).collect();
         let q = GpuBuffer::from_vec(vals.clone(), vec![1, head_dim]);
         let k = GpuBuffer::from_vec(vals.clone(), vec![1, head_dim]);
-        let (qr, kr) = partial_rotary_forward(&[0], &q, &k, head_dim, rotary_dim).unwrap();
+        let (qr, kr) = partial_rotary_forward(&[0], &q, &k, head_dim, rotary_dim, 10000.0).unwrap();
         // All values should be unchanged at position 0.
         for i in 0..head_dim {
             assert!(
@@ -617,7 +623,7 @@ mod tests {
         let vals: Vec<f16> = (1..=8).map(|i| f16::from_f32(i as f32)).collect();
         let q = GpuBuffer::from_vec(vals.clone(), vec![1, head_dim]);
         let k = GpuBuffer::from_vec(vals.clone(), vec![1, head_dim]);
-        let (qr, kr) = partial_rotary_forward(&[50], &q, &k, head_dim, rotary_dim).unwrap();
+        let (qr, kr) = partial_rotary_forward(&[50], &q, &k, head_dim, rotary_dim, 10000.0).unwrap();
         // Pass-through dims (indices 4..8) should be unchanged.
         for i in rotary_dim..head_dim {
             assert!(
@@ -652,7 +658,7 @@ mod tests {
         let q = GpuBuffer::from_vec(vals.clone(), vec![1, head_dim]);
         let k = GpuBuffer::from_vec(vals.clone(), vec![1, head_dim]);
         let (qr_partial, kr_partial) =
-            partial_rotary_forward(&[10], &q, &k, head_dim, head_dim).unwrap();
+            partial_rotary_forward(&[10], &q, &k, head_dim, head_dim, 10000.0).unwrap();
         let (qr_standard, kr_standard) = RotaryEmbedding::forward(&[10], &q, &k, head_dim).unwrap();
         for i in 0..head_dim {
             assert!((qr_partial.data[i].to_f32() - qr_standard.data[i].to_f32()).abs() < 0.01,);

--- a/crates/rvllm-model-runner/src/architectures/qwen2.rs
+++ b/crates/rvllm-model-runner/src/architectures/qwen2.rs
@@ -22,6 +22,7 @@ pub struct Qwen2ForCausalLM {
     head_dim: usize,
     vocab_size: usize,
     rms_norm_eps: f32,
+    rope_theta: f32,
     embed_tokens: GpuBuffer<f16>,
     layers: Vec<Qwen2Layer>,
     norm_weight: GpuBuffer<f16>,
@@ -125,7 +126,8 @@ impl Qwen2ForCausalLM {
             hidden_size: config.hidden_size,
             head_dim: config.head_dim,
             vocab_size: config.vocab_size,
-            rms_norm_eps: 1e-6, // Qwen2 uses 1e-6 by default.
+            rms_norm_eps: config.rms_norm_eps,
+            rope_theta: config.rope_theta,
             embed_tokens,
             layers,
             norm_weight,
@@ -154,8 +156,9 @@ impl Architecture for Qwen2ForCausalLM {
             let k = LinearLayer::forward(&normed, &layer.k_proj, layer.k_bias.as_ref())?;
             let v = LinearLayer::forward(&normed, &layer.v_proj, layer.v_bias.as_ref())?;
 
-            let (q_rot, k_rot) =
-                RotaryEmbedding::forward(&input.position_ids, &q, &k, self.head_dim)?;
+            let (q_rot, k_rot) = RotaryEmbedding::forward_with_base(
+                &input.position_ids, &q, &k, self.head_dim, self.rope_theta,
+            )?;
 
             let attn_out =
                 attention.forward(&q_rot, &k_rot, &v, &input.attention_metadata, layer_idx)?;

--- a/crates/rvllm-model-runner/src/layers/rotary.rs
+++ b/crates/rvllm-model-runner/src/layers/rotary.rs
@@ -92,8 +92,19 @@ impl RotaryEmbedding {
         key: &GpuBuffer<f16>,
         head_dim: usize,
     ) -> Result<(GpuBuffer<f16>, GpuBuffer<f16>)> {
+        Self::forward_with_base(positions, query, key, head_dim, 10000.0)
+    }
+
+    /// Static forward with configurable RoPE base frequency.
+    pub fn forward_with_base(
+        positions: &[u32],
+        query: &GpuBuffer<f16>,
+        key: &GpuBuffer<f16>,
+        head_dim: usize,
+        base: f32,
+    ) -> Result<(GpuBuffer<f16>, GpuBuffer<f16>)> {
         let max_pos = positions.iter().copied().max().unwrap_or(0) as usize + 1;
-        let emb = Self::new(head_dim, max_pos, 10000.0);
+        let emb = Self::new(head_dim, max_pos, base);
         emb.apply(positions, query, key)
     }
 

--- a/crates/rvllm-worker/src/gpu_worker.rs
+++ b/crates/rvllm-worker/src/gpu_worker.rs
@@ -671,7 +671,11 @@ impl GpuWorker {
 
             // Pre-capture CUDA graphs for common decode batch sizes to avoid
             // mid-generation capture stalls.
-            if let Err(e) = self.precapture_decode_graphs() {
+            // RVLLM_NO_GRAPH=1 disables graph capture entirely (useful for debugging).
+            if std::env::var("RVLLM_NO_GRAPH").map_or(false, |v| v == "1") {
+                info!("RVLLM_NO_GRAPH=1: disabling CUDA graph capture/replay");
+                self.graph_runner.pool_mut().disable();
+            } else if let Err(e) = self.precapture_decode_graphs() {
                 warn!("pre-capture failed: {e} -- graphs will be captured lazily");
             }
         }


### PR DESCRIPTION
## Summary

- **CPU reference path** (`RotaryEmbedding::forward`) hardcodes `base: 10000.0`, but models like Qwen2.5 use `rope_theta: 1000000.0` and Llama-3 uses `500000.0`. Added `forward_with_base()` and updated all 10 architectures to read `rope_theta` from `ModelRunnerConfig`. Also uses `config.rms_norm_eps` instead of hardcoded values.

- **`RVLLM_NO_GRAPH=1` env var** disables CUDA graph capture and replay. Useful for debugging inference issues without graph-related complications.

## Changes

### Commit 1: rope_theta fix
- Add `RotaryEmbedding::forward_with_base()` that accepts a configurable base frequency
- All 10 architectures (Llama, Qwen2, Mistral, Mixtral, DeepSeek, Gemma, GPT-NeoX, Cohere, Phi, Embedding) now pass `config.rope_theta` to RoPE
- Use `config.rms_norm_eps` instead of hardcoded values in all architectures

### Commit 2: RVLLM_NO_GRAPH
- When `RVLLM_NO_GRAPH=1` is set, calls `graph_runner.pool_mut().disable()` to skip pre-capture and prevent graph replay
- Raw forward pass used for every decode step

## Test plan
- [x] `cargo test -p rvllm-model-runner` — 72 tests pass
- [x] Verified inference works on Qwen2.5-7B-Instruct via RunPod serverless (A100 80GB)